### PR TITLE
バリデーションの改善 #56

### DIFF
--- a/app/javascript/components/TheSignupDialog.vue
+++ b/app/javascript/components/TheSignupDialog.vue
@@ -151,7 +151,7 @@
                       <template #activator="{ on, attrs }">
                         <ValidationProvider
                           v-slot="{ errors }"
-                          rules="required|birthDateFormat"
+                          :rules="{ required: true, formFormat: /\d{4}-\d{2}-\d{2}/ }"
                           name="生年月日"
                         >
                           <v-text-field
@@ -186,7 +186,8 @@
                     <ValidationProvider
                       v-slot="{ errors }"
                       vid="email"
-                      rules="required|email"
+                      :rules="{ required: true,
+                                formFormat: /^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/i }"
                       name="メールアドレス"
                     >
                       <v-text-field
@@ -207,7 +208,7 @@
                   >
                     <ValidationProvider
                       v-slot="{ errors }"
-                      rules="required|min:6"
+                      :rules="{ required: true, min: 8, formFormat: /^(?=.*?[a-z])(?=.*?\d)[a-z\d]{8,}$/i }"
                       name="パスワード"
                     >
                       <v-text-field
@@ -215,7 +216,9 @@
                         :append-icon="show ? 'mdi-eye' : 'mdi-eye-off'"
                         :type="show ? 'text' : 'password'"
                         label="パスワード"
-                        hint="６文字以上で入力してください"
+                        placeholder="８文字以上の半角英数字"
+                        hint="＊英字、数字の両方を含めてください"
+                        :persistent-hint="true"
                         outlined
                         dense
                         counter
@@ -282,6 +285,7 @@ export default {
         return this.emailRegister = false
       }
       this.dialog = false
+      Object.assign(this.$data, this.$options.data())
     },
     signupForm() {
       this.emailRegister = true

--- a/app/javascript/pages/Login.vue
+++ b/app/javascript/pages/Login.vue
@@ -93,8 +93,8 @@
                             :append-icon="show ? 'mdi-eye' : 'mdi-eye-off'"
                             :type="show ? 'text' : 'password'"
                             label="パスワード"
-                            hint="６文字以上で入力してください"
                             outlined
+                            counter
                             background-color="#ECEFF1"
                             required
                             :error-messages="errors"

--- a/app/javascript/plugins/vee-validate.js
+++ b/app/javascript/plugins/vee-validate.js
@@ -1,16 +1,11 @@
 import { ValidationObserver, ValidationProvider, extend, setInteractionMode } from 'vee-validate'
-import { required, max, min, email } from 'vee-validate/dist/rules';
+import { required, max, min } from 'vee-validate/dist/rules';
 
 setInteractionMode("eager");
 
 extend("required", {
   ...required,
   message: "{_field_}を入力してください"
-})
-
-extend("email", {
-  ...email,
-  message: "{_field_}を正しく入力してください"
 })
 
 extend("max", {
@@ -23,9 +18,10 @@ extend("min", {
   message: "{_field_}は{length}文字以上で入力してください"
 })
 
-extend("birthDateFormat", {
-  validate(value) {
-    return value.match(/\d{4}-\d{2}-\d{2}/)
+extend("formFormat", {
+  params: ['format'],
+  validate(value, { format }) {
+    return value.match(format)
   },
   message: "入力形式が正しくありません"
 })

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   EMAIL_FORMAT = /\A[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}\z/i
-  PASSWORD_FORMAT = /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[a-zA-Z\d]{8,100}+\z/
+  PASSWORD_FORMAT = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{8,}+\z/i
 
   validates :first_name, presence: true, length: { maximum: 30 }
   validates :last_name, presence: true, length: { maximum: 30 }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,13 +35,12 @@ RSpec.describe User, type: :model do
                                         'foo@bar+baz.com').for(:email)
       end
       it 'valid password' do
-        is_expected.to allow_values('Rails0123',
-                                    '0123RAILs').for(:password)
+        is_expected.to allow_values('rails0123',
+                                    'Rails0123',
+                                    'a1' * 200).for(:password)
       end
       it 'invalid password' do
-        is_expected.to_not allow_values(' ' * 8,
-                                        'RAILS0123',
-                                        'rails0123').for(:password)
+        is_expected.to_not allow_values(' ' * 8).for(:password)
       end
     end
 


### PR DESCRIPTION
## やったこと
パスワードのバリデーションを変更
半角英大文字、小文字、数字の８文字以上１００文字以下から
半角英数字、８文字以上、上限なしに変更

## やらないこと
特になし

## できるようになること（ユーザ目線）
パスワードが１００文字以上でも登録できるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
テストとフォーム上でパスワードが指定された形式で登録できることを確認

## その他
特になし
close #56 