### PR TITLE
account_activations_controllerの作成 #20

### DIFF
--- a/app/controllers/api/v1/account_activations_controller.rb
+++ b/app/controllers/api/v1/account_activations_controller.rb
@@ -1,0 +1,37 @@
+class Api::V1::AccountActivationsController < ApplicationController
+  def create
+    if (user = User.find_by(email: params[:email]))
+      user.setup_activation
+      user.activation_token_expires_at = Time.zone.now.since(1.day)
+
+      if user.save
+        UserMailer.activation_needed_email(user).deliver_now
+        head :ok
+      else
+        render json: { errors: user.errors.full_messages }, status: :bad_request
+      end
+
+    else
+      render json: { message: 'ユーザーが見つかりませんでした' }, status: :bad_request
+    end
+  end
+
+  def edit
+    User.load_from_activation_token(params[:id]) do |user, failure_reason|
+      if user && !failure_reason.present?
+        user.activate!
+        user.update_column(:activation_token_expires_at, nil)
+        token = create_token(user)
+        cookies[:token] = { value: token, expires: 1.month.from_now, secure: Rails.env.production?, httponly: true, same_site: 'Lax' }
+        redirect_to root_path
+      else
+        case failure_reason
+        when :user_not_found
+          render json: { message: '既に認証済みです' }, status: :bad_request
+        when :token_expired
+          render json: { message: '有効期限切れです' }, status: :bad_request
+        end
+      end
+    end
+  end
+end

--- a/app/javascript/components/TheSignupDialog.vue
+++ b/app/javascript/components/TheSignupDialog.vue
@@ -11,7 +11,7 @@
           @click="closeSignupDialog"
         >
           <v-icon
-            v-if="!emailRegister"
+            v-if="registerSelect || sendNeededEmail"
           >
             mdi-close
           </v-icon>
@@ -28,7 +28,7 @@
         </v-card-title>
         <v-divider />
 
-        <v-container v-if="!emailRegister">
+        <v-container v-if="registerSelect">
           <v-row>
             <v-col
               cols="12"
@@ -193,8 +193,10 @@
                     <ValidationProvider
                       v-slot="{ errors }"
                       vid="email"
-                      :rules="{ required: true,
-                                formFormat: /^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/i }"
+                      :rules="{
+                        required: true,
+                        formFormat: /^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/i
+                      }"
                       name="メールアドレス"
                     >
                       <v-text-field
@@ -254,6 +256,79 @@
             </v-form>
           </ValidationObserver>
         </v-card-text>
+        <v-card-text v-if="sendNeededEmail">
+          <v-container>
+            <v-row>
+              <v-col
+                cols="12"
+                class="pb-0 mt-9"
+                align="center"
+              >
+                <p
+                  class="font-weight-bold"
+                  style="color: black"
+                >
+                  ご登録されたアドレスにアカウント認証メールを送信しました
+                </p>
+              </v-col>
+              <v-col
+                cols="12"
+                class="pt-0"
+              >
+                <v-sheet
+                  class="d-flex"
+                  rounded
+                  color="grey lighten-3"
+                  height="50"
+                >
+                  <v-col
+                    cols="12"
+                    align="center"
+                  >
+                    <p>{{ user.email }}</p>
+                  </v-col>
+                </v-sheet>
+              </v-col>
+              <v-col
+                cols="12"
+                class="pt-0"
+              >
+                <p style="font-size: 8px;">
+                  ＊リンクをクリックしてアカウントを認証してください。
+                  <br>
+                  ＊リンクの有効期限は２４時間以内です。
+                </p>
+              </v-col>
+            </v-row>
+            <v-divider />
+          </v-container>
+          <v-container>
+            <v-row>
+              <v-col
+                cols="12"
+                class="pb-0"
+                align="center"
+              >
+                <p
+                  class="font-weight-bold"
+                  style="color: black"
+                >
+                  メールが届かない方はこちら
+                </p>
+              </v-col>
+              <v-col class="pt-0">
+                <v-btn
+                  block
+                  depressed
+                  outlined
+                  @click="sendAgainEmail"
+                >
+                  再度送信
+                </v-btn>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
       </v-card>
     </v-dialog>
   </div>
@@ -264,7 +339,9 @@ export default {
   data() {
     return {
       dialog: false,
+      registerSelect: false,
       emailRegister: false,
+      sendNeededEmail: false,
       password: "",
       show: false,
       menu: false,
@@ -286,16 +363,19 @@ export default {
   methods: {
     open() {
       this.dialog = true
+      this.registerSelect = true
     },
     closeSignupDialog() {
       if (this.emailRegister === true) {
-        return this.emailRegister = false
+        this.emailRegister = false
+        return this.registerSelect = true
       }
       this.dialog = false
       Object.assign(this.$data, this.$options.data())
     },
     signupForm() {
       this.emailRegister = true
+      this.registerSelect = false
     },
     save(date) {
       this.$refs.menu.save(date)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,7 @@
 class UserMailer < ApplicationMailer
   def activation_needed_email(user)
     @user = user
-    @url  = active_api_v1_user_url(@user.activation_token)
+    @url  = edit_api_v1_account_activation_url(@user.activation_token)
     mail(to: user.email, subject: 'Welcome to My Awesome Site')
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  before_save :email_downcase
+  before_save :email_downcase, if: -> { email_changed? }
   before_create :set_activation_token_exp
   before_update :setup_activation, if: -> { email_changed? }
   after_update :send_activation_needed_email!, if: -> { previous_changes['email'].present? }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,13 +4,13 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, only: %i[create] do
-        get :active, on: :member
         collection do
           scope module: :users do
             resource :current, only: %i[show update]
           end
         end
       end
+      resources :account_activations, only: %i[create edit]
       post '/login', to: 'user_sessions#create'
       delete '/logout', to: 'user_sessions#destroy'
     end


### PR DESCRIPTION
## やったこと
account_activations_controllerの作成
新規登録後にモーダルに認証成功メールを送信したことを通知

## やらないこと
認証メールが届かない場合の実装

## できるようになること（ユーザ目線）
新規登録後にモーダルに認証成功メールを送信したことを通知されるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
新規登録後にモーダルに表示されることを確認

## その他
特になし
