### PR TITLE
SignupDialogno #20

### DIFF
--- a/app/controllers/api/v1/account_activations_controller.rb
+++ b/app/controllers/api/v1/account_activations_controller.rb
@@ -18,15 +18,14 @@ class Api::V1::AccountActivationsController < ApplicationController
   def edit
     User.load_from_activation_token(params[:id]) do |user, failure_reason|
       if user && !failure_reason.present?
-        user.activate!
-        user.update_column(:activation_token_expires_at, nil)
-        token = create_token(user)
+        user.activate_attributes
+        token = user.create_token
         cookies[:token] = { value: token, expires: 1.month.from_now, secure: Rails.env.production?, httponly: true, same_site: 'Lax' }
         redirect_to root_path
       else
         case failure_reason
         when :user_not_found
-          render json: { message: '既に認証済みです' }, status: :bad_request
+          render json: { message: '既に認証済み又はURLが無効です' }, status: :bad_request
         when :token_expired
           render json: { message: '有効期限切れです' }, status: :bad_request
         end

--- a/app/javascript/components/TheSignupDialog.vue
+++ b/app/javascript/components/TheSignupDialog.vue
@@ -394,6 +394,16 @@ export default {
           email: ["このメールアドレスは既に使用されています"]
         })
       }
+    },
+    async sendAgainEmail() {
+      try {
+        const response = await this.$axios.post("/api/v1/account_activations", {
+          email: this.user.email
+        })
+        console.log(response);
+      } catch(err) {
+        console.log(err.response);
+      }
     }
   }
 }

--- a/app/javascript/components/TheSignupDialog.vue
+++ b/app/javascript/components/TheSignupDialog.vue
@@ -385,8 +385,6 @@ export default {
         const response = await this.$axios.post("/api/v1/users", {
           user: this.user
         })
-        this.dialog = false
-        Object.assign(this.$data, this.$options.data())
         this.$refs.observer.reset()
       } catch(err) {
         console.log(err.response);

--- a/app/javascript/components/TheSignupDialog.vue
+++ b/app/javascript/components/TheSignupDialog.vue
@@ -386,6 +386,8 @@ export default {
           user: this.user
         })
         this.$refs.observer.reset()
+        this.emailRegister = false
+        this.sendNeededEmail = true
       } catch(err) {
         console.log(err.response);
         this.$refs.observer.setErrors({


### PR DESCRIPTION
## やったこと
不要なコードを削除
新規登録後に登録フォームの非表示にして通知ページを表示する処理
認証メールを再度送信するための処理の実装

## やらないこと
特になし

## できるようになること（ユーザ目線）
新規登録後に通知ページが表示される
認証メールが届かない場合に再度送信できるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
登録後に通知ページが表示されることを確認
再度送信ボタンをクリックするとメールが送られてくることを確認

## その他
特になし
