### PR TITLE
認証メール再送信モーダルの作成・処理の実装 #20

### DIFF
--- a/app/javascript/components/ResendActivationEmailDialog.vue
+++ b/app/javascript/components/ResendActivationEmailDialog.vue
@@ -1,0 +1,51 @@
+<template>
+  <v-dialog
+    v-model="dialog"
+    width="500"
+  >
+    <v-card>
+      <v-card-title>
+        <span class="mx-auto">認証メール再送信</span>
+      </v-card-title>
+      <v-divider />
+      <v-card-text class="pt-6 pb-0">
+        <v-container>
+          <v-row>
+            <v-col cols="12" class="pb-0">
+              <v-text-field
+                outlined
+                label="メールアドレス"
+                dense
+                background-color="#ECEFF1"
+                required
+              />
+            </v-col>
+            <v-col align="right" cols="12" class="pt-0">
+              <v-btn
+                color="blue darken-1"
+                text
+              >
+                送信
+              </v-btn>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      dialog: false
+    }
+  },
+  methods: {
+    open() {
+      this.dialog = true
+    }
+  }
+}
+</script>

--- a/app/javascript/components/ResendActivationEmailDialog.vue
+++ b/app/javascript/components/ResendActivationEmailDialog.vue
@@ -9,29 +9,44 @@
       </v-card-title>
       <v-divider />
       <v-card-text class="pt-6 pb-0">
-        <v-container>
-          <v-row>
-            <v-col cols="12" class="pb-0">
-              <v-text-field
-                v-model="email"
-                outlined
-                label="メールアドレス"
-                dense
-                background-color="#ECEFF1"
-                required
-              />
-            </v-col>
-            <v-col align="right" cols="12" class="pt-0">
-              <v-btn
-                color="blue darken-1"
-                text
-                @click="sendEmail"
-              >
-                送信
-              </v-btn>
-            </v-col>
-          </v-row>
-        </v-container>
+        <ValidationObserver ref="observer" v-slot="{ handleSubmit }">
+          <v-form>
+            <v-container>
+              <v-row>
+                <v-col cols="12" class="pb-0">
+                  <ValidationProvider
+                    vid="email"
+                    :rules="{
+                      required: true,
+                      formFormat: /^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/i
+                     }"
+                    name="メールアドレス"
+                    v-slot="{ errors }"
+                  >
+                    <v-text-field
+                      v-model="email"
+                      outlined
+                      label="メールアドレス"
+                      dense
+                      background-color="#ECEFF1"
+                      required
+                      :error-messages="errors"
+                    />
+                  </ValidationProvider>
+                </v-col>
+                <v-col align="right" cols="12" class="pt-0">
+                  <v-btn
+                    color="blue darken-1"
+                    text
+                    @click="handleSubmit(sendEmail)"
+                  >
+                    送信
+                  </v-btn>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-form>
+        </ValidationObserver>
       </v-card-text>
     </v-card>
   </v-dialog>
@@ -56,7 +71,9 @@ export default {
         })
         Object.assign(this.$data, this.$options.data())
       } catch(err) {
-        console.log(err.response);
+        this.$refs.observer.setErrors({
+          email: ["ユーザーが見つかりませんでした"]
+        })
       }
     }
   }

--- a/app/javascript/components/ResendActivationEmailDialog.vue
+++ b/app/javascript/components/ResendActivationEmailDialog.vue
@@ -13,6 +13,7 @@
           <v-row>
             <v-col cols="12" class="pb-0">
               <v-text-field
+                v-model="email"
                 outlined
                 label="メールアドレス"
                 dense
@@ -24,6 +25,7 @@
               <v-btn
                 color="blue darken-1"
                 text
+                @click="sendEmail"
               >
                 送信
               </v-btn>
@@ -39,12 +41,23 @@
 export default {
   data() {
     return {
-      dialog: false
+      dialog: false,
+      email: ""
     }
   },
   methods: {
     open() {
       this.dialog = true
+    },
+    async sendEmail() {
+      try {
+        await this.$axios.post("/api/v1/account_activations", {
+          email: this.email
+        })
+        Object.assign(this.$data, this.$options.data())
+      } catch(err) {
+        console.log(err.response);
+      }
     }
   }
 }

--- a/app/javascript/components/TheSendAccountActivationDialog.vue
+++ b/app/javascript/components/TheSendAccountActivationDialog.vue
@@ -1,9 +1,0 @@
-<template>
-
-</template>
-
-<script>
-export default {
-
-}
-</script>

--- a/app/javascript/components/TheSendAccountActivationDialog.vue
+++ b/app/javascript/components/TheSendAccountActivationDialog.vue
@@ -1,0 +1,9 @@
+<template>
+
+</template>
+
+<script>
+export default {
+
+}
+</script>

--- a/app/javascript/pages/Login.vue
+++ b/app/javascript/pages/Login.vue
@@ -168,15 +168,20 @@
     <the-signup-dialog
       ref="signupDialog"
     />
+    <the-send-account-activation-dialog
+      ref="accountActivationDialog"
+    />
   </div>
 </template>
 
 <script>
 import TheSignupDialog from "../components/TheSignupDialog"
+import TheSendAccountActivationDialog from "../components/TheSendAccountActivationDialog"
 
 export default {
   components: {
-    TheSignupDialog
+    TheSignupDialog,
+    TheSendAccountActivationDialog
   },
   data() {
     return {

--- a/app/javascript/pages/Login.vue
+++ b/app/javascript/pages/Login.vue
@@ -40,7 +40,7 @@
                 </p>
                 <p style="font-size: 8px;">
                   ＊アカウント認証メールが届かない方は
-                  <strong @click="openSendAccountDialog" style="cursor: pointer; color: red;">こちら</strong>
+                  <strong @click="openActivationEmail" style="cursor: pointer; color: red;">こちら</strong>
                   をクリック
                 </p>
               </v-col>
@@ -204,6 +204,9 @@ export default {
       } catch(err) {
         console.log(err.response);
       }
+    },
+    openActivationEmail() {
+      this.$refs.activationEmailDialog.open()
     }
   }
 }

--- a/app/javascript/pages/Login.vue
+++ b/app/javascript/pages/Login.vue
@@ -168,20 +168,20 @@
     <the-signup-dialog
       ref="signupDialog"
     />
-    <the-send-account-activation-dialog
-      ref="accountActivationDialog"
+    <resend-activation-email-dialog
+      ref="activationEmailDialog"
     />
   </div>
 </template>
 
 <script>
 import TheSignupDialog from "../components/TheSignupDialog"
-import TheSendAccountActivationDialog from "../components/TheSendAccountActivationDialog"
+import ResendActivationEmailDialog from "../components/ResendActivationEmailDialog"
 
 export default {
   components: {
     TheSignupDialog,
-    TheSendAccountActivationDialog
+    ResendActivationEmailDialog
   },
   data() {
     return {


### PR DESCRIPTION
## やったこと
認証メール再送信モーダルの作成・処理の実装

## やらないこと
認証後の通知ページの作成

## できるようになること（ユーザ目線）
認証メールが届かない場合、登録したアドレスを送信することで、
認証メールを受け取ることができる

## できなくなること（ユーザ目線）
特になし

## 動作確認
認証メールを受け取ることを確認

## その他
特になし
