### PR TITLE
既に認証済みの場合の処理を実装 #20

### DIFF
--- a/app/controllers/api/v1/account_activations_controller.rb
+++ b/app/controllers/api/v1/account_activations_controller.rb
@@ -1,15 +1,19 @@
 class Api::V1::AccountActivationsController < ApplicationController
   def create
     if (user = User.find_by(email: params[:email]))
-      user.setup_activation_attributes
-      if user.save
-        UserMailer.activation_needed_email(user).deliver_now
-        head :ok
+      if !user.activation_token.nil?
+        user.setup_activation_attributes
+        if user.save
+          UserMailer.activation_needed_email(user).deliver_now
+          head :ok
+        else
+          render json: { email: '送信に失敗しました。もう一度お試しください。' }, status: :bad_request
+        end
       else
-        render json: { message: '送信に失敗しました。もう一度お試しください。' }, status: :bad_request
+        render json: { email: 'このメールアドレスは認証済みです' }, status: :bad_request
       end
     else
-      render json: { message: 'ユーザーが見つかりませんでした' }, status: :bad_request
+      render json: { email: 'ユーザーが見つかりませんでした' }, status: :bad_request
     end
   end
 

--- a/app/javascript/components/ResendActivationEmailDialog.vue
+++ b/app/javascript/components/ResendActivationEmailDialog.vue
@@ -96,9 +96,7 @@ export default {
         this.emailForm = false
         this.sendActivationEmail = true
       } catch(err) {
-        this.$refs.observer.setErrors({
-          email: ["ユーザーが見つかりませんでした"]
-        })
+        this.$refs.observer.setErrors(err.response.data)
       }
     }
   }

--- a/spec/requests/api/v1/account_activations_spec.rb
+++ b/spec/requests/api/v1/account_activations_spec.rb
@@ -23,8 +23,23 @@ RSpec.describe 'Api::V1::AccountActivations', type: :request do
         expect(response.status).to eq(400)
       end
 
-      it '認証メールが送信されない' do
-        expect(ActionMailer::Base.deliveries.size).to eq(1) #ユーザーが作成されるタイミングで一通送られるので1
+      it 'エラーメッセージを返す' do
+        expect(json['email']).to eq('ユーザーが見つかりませんでした')
+      end
+    end
+
+    context '既に認証済みの場合' do
+      before do
+        user.activate!
+        post '/api/v1/account_activations', headers: @header, params: { email: user.email }
+      end
+
+      it '失敗して４００を返す' do
+        expect(response.status).to eq(400)
+      end
+
+      it 'エラーメッセージを返す' do
+        expect(json['email']).to eq('このメールアドレスは認証済みです')
       end
     end
   end


### PR DESCRIPTION
## やったこと
既に認証済みの場合の処理を実装
以前は認証済みでも関係なく認証メールを送れたが、その必要はないため認証済みの場合は
メールを送れないように変更

## やらないこと
特になし

## できるようになること（ユーザ目線）
自分以外のユーザーがアドレスにメールを送ってくる可能性がなくなる

## できなくなること（ユーザ目線）
認証後にメールを送信できない

## 動作確認
想定通りに動くことを確認

## その他
特になし
