### PR TITLE
プロフィールページ(マイページ)をざっくりと作成 #17

### DIFF
--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="mt-10 mb-4">
+    <speed-dial
+      v-if="$vuetify.breakpoint.mobile"
+    />
+    <profile
+      :user="currentUser"
+    />
+    <div
+      class="profile-tabs"
+    >
+      <v-tabs
+        color="black"
+        :fixed-tabs="$vuetify.breakpoint.mobile"
+        :class="$vuetify.breakpoint.mobile ? 'px-4' : ''"
+        background-color="#FAFAFA"
+      >
+        <v-tab
+          class="mr-5 font-weight-bold"
+          @click="changeUserInformation"
+        >
+          ユーザー情報
+        </v-tab>
+        <v-tab
+          class="font-weight-bold"
+          @click="changeReviewList"
+        >
+          レビュー一覧
+        </v-tab>
+      </v-tabs>
+    </div>
+    <v-divider />
+    <div class="profile-contents mt-4">
+      <information
+        v-if="userInformation"
+        :user="currentUser"
+      />
+      <review-list
+        v-if="reviewList"
+        :user="currentUser"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from "vuex"
+import SpeedDial from "../parts/mobile/SpeedDial"
+import Profile from "../parts/Profile"
+import ReviewList from "../parts/ReviewList"
+import Information from "../parts/Information"
+
+export default {
+  components: {
+    SpeedDial,
+    Profile,
+    ReviewList,
+    Information
+  },
+  data() {
+    return {
+      fab: false,
+      userInformation: true,
+      reviewList: false,
+      rating: 3.1
+    }
+  },
+  computed: {
+    ...mapGetters({ currentUser: "user/currentUser" }),
+    fullName() {
+      return `${this.currentUser.last_name} ${this.currentUser.first_name}`
+    },
+    player() {
+      if (this.currentUser.role === "player") {
+        return true
+      } else {
+        return false
+      }
+    }
+  },
+  methods: {
+    changeUserInformation() {
+      this.userInformation = true
+      this.reviewList = false
+    },
+    changeReviewList() {
+      this.reviewList = true
+      this.userInformation = false
+    }
+  }
+}
+</script>
+
+<style scoped>
+  .profile-tabs {
+    max-width: 1018px;
+    margin: 0 auto;
+  }
+  .profile-contents {
+    max-width: 1050px;
+    margin: 0 auto;
+  }
+</style>

--- a/app/javascript/components/parts/Information.vue
+++ b/app/javascript/components/parts/Information.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-container>
+    <v-row>
+      <!-- 経歴 -->
+      <v-col cols="12">
+        <information-career />
+      </v-col>
+      <!-- つながり -->
+      <v-col cols="12">
+        <information-relation
+          :user="user"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import InformationCareer from "./InformationCareer"
+import InformationRelation from "./InformationRelation"
+
+export default {
+  components: {
+     InformationCareer,
+     InformationRelation
+  },
+  props: {
+    user: {
+      type: Object,
+      default: () => {},
+      required: true
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/InformationCareer.vue
+++ b/app/javascript/components/parts/InformationCareer.vue
@@ -1,0 +1,81 @@
+<template>
+  <v-card
+    elevation="1"
+    outlined
+  >
+    <v-card-title class="font-weight-bold">
+      経歴
+    </v-card-title>
+    <v-card-text>
+      <v-container>
+        <v-row>
+          <v-col
+            class="font-weight-bold"
+            align="center"
+            cols="12"
+            md="4"
+          >
+            川崎サッカークラブ
+            <v-icon
+              v-if="!$vuetify.breakpoint.mobile"
+              style="float: right"
+            >
+              mdi-arrow-right
+            </v-icon>
+          </v-col>
+          <v-col
+            v-if="$vuetify.breakpoint.mobile"
+            class="font-weight-bold"
+            align="center"
+            cols="12"
+          >
+            <v-icon>
+              mdi-arrow-down
+            </v-icon>
+          </v-col>
+          <v-col
+            align="center"
+            cols="12"
+            lg="4"
+            class="font-weight-bold"
+          >
+            川崎フロンターレU15
+            <v-icon
+              v-if="!$vuetify.breakpoint.mobile"
+              style="float: right"
+            >
+              mdi-arrow-right
+            </v-icon>
+          </v-col>
+          <v-col
+            v-if="$vuetify.breakpoint.mobile"
+            class="font-weight-bold"
+            align="center"
+            cols="12"
+          >
+            <v-icon>
+              mdi-arrow-down
+            </v-icon>
+          </v-col>
+          <v-col
+            class="font-weight-bold"
+            align="center"
+            cols="12"
+            lg="4"
+          >
+            <v-icon color="#EF5350">
+              mdi-check-bold
+            </v-icon>
+            川崎フロンターレU18
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+export default {
+
+}
+</script>

--- a/app/javascript/components/parts/InformationRelation.vue
+++ b/app/javascript/components/parts/InformationRelation.vue
@@ -1,0 +1,81 @@
+<template>
+  <v-card
+    elevation="1"
+    outlined
+  >
+    <v-card-title class="font-weight-bold">
+      つながり
+    </v-card-title>
+    <v-card-text>
+      <v-container>
+        <v-row>
+          <v-col cols="12">
+            <v-tabs>
+              <v-tab class="font-weight-bold">
+                フォロー
+              </v-tab>
+              <v-tab class="font-weight-bold">
+                フォロワー
+              </v-tab>
+            </v-tabs>
+          </v-col>
+          <v-col
+            cols="12"
+            lg="6"
+          >
+            <v-card
+              rounded
+              outlined
+            >
+              <v-card-text
+                class="px-0 py-0"
+              >
+                <v-list>
+                  <v-list-item>
+                    <v-list-item-avatar>
+                      <v-img
+                        :src="user.avatar"
+                      />
+                    </v-list-item-avatar>
+                    <v-list-item-content>
+                      <v-list-item-title class="font-weight-black">
+                        {{ fullName }}
+                      </v-list-item-title>
+                    </v-list-item-content>
+                    <v-list-item-action>
+                      <v-btn
+                        rounded
+                        color="primary"
+                        outlined
+                        class="font-weight-bold text-capitalize"
+                      >
+                        Follow
+                      </v-btn>
+                    </v-list-item-action>
+                  </v-list-item>
+                </v-list>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: {
+    user: {
+      type: Object,
+      default: () => {},
+      required: true
+    }
+  },
+  computed: {
+    fullName() {
+      return `${this.user.last_name} ${this.user.first_name}`
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/Profile.vue
+++ b/app/javascript/components/parts/Profile.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="profile-top">
+    <v-list
+      color="#FAFAFA"
+    >
+      <v-list-item>
+        <!-- モバイル用アバター -->
+        <v-badge
+          v-if="$vuetify.breakpoint.mobile"
+          bottom
+          icon="mdi-pencil-outline"
+          dark
+          overlap
+          color="success"
+          offset-x="38"
+          offset-y="35"
+        >
+          <v-list-item-avatar
+            size="110"
+            class="ml-n1"
+          >
+            <v-img
+              :src="user.avatar"
+            />
+          </v-list-item-avatar>
+        </v-badge>
+        <!-- PC用アバター -->
+        <v-list-item-avatar
+          v-if="!$vuetify.breakpoint.mobile"
+          size="100"
+        >
+          <v-img
+            :src="user.avatar"
+          />
+        </v-list-item-avatar>
+        <v-list-item-content class="mt-2">
+          <profile-title
+            v-if="!$vuetify.breakpoint.mobile"
+            :user="user"
+          />
+          <profile-card
+            v-if="$vuetify.breakpoint.mobile"
+          />
+        </v-list-item-content>
+        <!-- プロフィールアクション -->
+        <profile-action
+          :user="user"
+        />
+      </v-list-item>
+      <profile-title
+        v-if="$vuetify.breakpoint.mobile"
+        :user="user"
+      />
+    </v-list>
+    <!-- 自己紹介文 -->
+    <v-container class="px-4 pt-0">
+      <v-row>
+        <v-col
+          cols="12"
+          lg="9"
+        >
+          <p
+            class="text-caption"
+            style="color: #616161;"
+          >
+            〇〇高校の中山太郎です。MFでプレイしています。。よろしくお願いします。
+          </p>
+        </v-col>
+        <v-col
+          v-if="!$vuetify.breakpoint.mobile"
+          cols="3"
+        >
+          <profile-card />
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+
+<script>
+import ProfileAction from "./ProfileAction"
+import ProfileTitle from "./ProfileTitle"
+import ProfileCard from "./ProfileCard"
+
+export default {
+  components: {
+    ProfileAction,
+    ProfileTitle,
+    ProfileCard
+  },
+  props: {
+    user: {
+      type: Object,
+      default: () => {},
+      required: true
+    }
+  },
+}
+</script>
+
+<style scoped>
+  .profile-top {
+    max-width: 1050px;
+    margin: 0 auto;
+  }
+</style>

--- a/app/javascript/components/parts/ProfileAction.vue
+++ b/app/javascript/components/parts/ProfileAction.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <!-- ログインユーザーの場合 -->
+    <v-btn
+      v-if="!$vuetify.breakpoint.mobile"
+      rounded
+      class="font-weight-bold px-2 py-5 text-caption"
+      outlined
+      x-large
+      color="primary"
+    >
+      <v-icon>
+        mdi-pencil-outline
+      </v-icon>
+      プロフィール編集
+    </v-btn>
+    <!-- 他のユーザーの場合 -->
+    <!-- <template
+      v-if="!$vuetify.breakpoint.mobile"
+    >
+      <v-btn
+        class="mr-4"
+        outlined
+        color="primary"
+        fab
+      >
+        <v-icon>
+          mdi-account-plus
+        </v-icon>
+      </v-btn>
+      <v-btn
+        rounded
+        x-large
+        depressed
+        color="primary"
+        dark
+        class="font-weight-bold text-capitalize"
+      >
+        Review
+      </v-btn>
+    </template> -->
+  </div>
+</template>

--- a/app/javascript/components/parts/ProfileCard.vue
+++ b/app/javascript/components/parts/ProfileCard.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-card outlined>
+    <v-simple-table dense>
+      <template #default>
+        <tbody>
+          <tr
+            v-for="item in desserts"
+            :key="item.name"
+          >
+            <td>
+              <span class="font-weight-bold" style="font-size: 10px">{{ item.name }}</span>
+            </td>
+            <td
+              align="end"
+            >
+              <span class="font-weight-bold" style="font-size: 10px">{{ item.calories }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </template>
+    </v-simple-table>
+  </v-card>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      rating: 3.1,
+      desserts: [
+          {
+            name: "所属チーム",
+            calories: "川崎フロンターレU18",
+          },
+          {
+            name: "ポジション",
+            calories: "MF",
+          },
+          {
+            name: "背番号",
+            calories: 10,
+          },
+        ],
+    }
+  },
+}
+</script>
+
+<style scoped>
+  .v-data-table
+    tbody
+    tr:hover:not(.v-data-table__expanded__content) {
+    background: #ffffff !important;
+  }
+</style>

--- a/app/javascript/components/parts/ProfileTitle.vue
+++ b/app/javascript/components/parts/ProfileTitle.vue
@@ -1,0 +1,60 @@
+<template>
+  <div :class="$vuetify.breakpoint.mobile ? 'ml-3' : ''">
+    <v-list-item-title
+      class="font-weight-black text-h5"
+      style="margin-left: 2px;"
+    >
+      <v-tooltip bottom>
+        <template #activator="{ on, attrs }">
+          <v-icon
+            v-bind="attrs"
+            v-on="on"
+          >
+            mdi-soccer
+          </v-icon>
+        </template>
+        プレイヤー
+      </v-tooltip>
+      <span style="position: relative; top: 2px;">{{ fullName }}</span>
+    </v-list-item-title>
+    <v-list-item-title
+      class="mt-1"
+    >
+      <v-rating
+        v-model="rating"
+        background-color="#ef5350"
+        color="#ef5350"
+        class="mr-1 float-left"
+        readonly
+        dense
+        :half-increments="true"
+      />
+      <span
+        class="text-h5 font-weight-bold"
+        style="position: relative; bottom: 2px;"
+      >{{ rating }}</span>
+    </v-list-item-title>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    user: {
+      type: Object,
+      default: () => {},
+      required: true
+    }
+  },
+  data() {
+    return {
+      rating: 3.1
+    }
+  },
+  computed: {
+    fullName() {
+      return `${this.user.last_name} ${this.user.first_name}`
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/ReviewList.vue
+++ b/app/javascript/components/parts/ReviewList.vue
@@ -1,0 +1,119 @@
+<template>
+  <v-container class="d-flex px-0 py-0">
+    <v-col
+      cols="12"
+      lg="8"
+    >
+      <v-card
+        elevation="1"
+        outlined
+        class="mb-8"
+      >
+        <v-card-title>
+          <v-avatar class="mr-4">
+            <v-img
+              :src="user.avatar"
+            />
+          </v-avatar>
+          <v-icon
+            small
+            class="mr-1"
+          >
+            mdi-soccer
+          </v-icon>
+          <span class="font-weight-bold text-subtitle-1">{{ fullName }}</span>
+        </v-card-title>
+        <v-card-text class="pb-0">
+          <p class="mb-0">
+            とても良いプレーでした。とても良いプレーでしたとても良いプレとても良いプレーでした
+          </p>
+        </v-card-text>
+        <v-card-actions class="mr-4 mb-2">
+          <v-spacer />
+          <v-rating
+            v-model="rating"
+            align="right"
+            background-color="#ef5350"
+            color="#ef5350"
+            small
+            readonly
+            dense
+          />
+          <span class="mt-1 ml-1 font-weight-bold">{{ rating }}</span>
+        </v-card-actions>
+      </v-card>
+    </v-col>
+    <!-- 所属リーグのランキング -->
+    <v-col
+      v-if="!$vuetify.breakpoint.mobile"
+      cols="12"
+      lg="4"
+    >
+      <v-card outlined>
+        <v-card-title class="text-subtitle-1 font-weight-bold pb-0">
+          所属リーグのランキング
+        </v-card-title>
+        <v-card-text class="py-0">
+          <v-list two-line>
+            <v-list-item class="ml-4">
+              <span class="font-weight-bold mr-3 text-subtitle-1">
+                <v-icon color="#C0C0C0">
+                  mdi-crown
+                </v-icon>
+              </span>
+              <v-list-item-avatar class="mr-1">
+                <v-img
+                  :src="user.avatar"
+                />
+              </v-list-item-avatar>
+              <v-list-item-content>
+                <v-list-item-title
+                  class="font-weight-bold text-button"
+                  style="position: relative; top: 13px; left: 3px;"
+                >
+                  {{ fullName }}
+                </v-list-item-title>
+                <v-list-item-title class="mt-1">
+                  <v-rating
+                    v-model="rating"
+                    background-color="#ef5350"
+                    color="#ef5350"
+                    class="mr-1 float-left"
+                    readonly
+                    small
+                    dense
+                    style="position: relative; top: 6px;"
+                    :half-increments="true"
+                  />
+                  <span class="text-button font-weight-bold">{{ rating }}</span>
+                </v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+        </v-card-text>
+      </v-card>
+    </v-col>
+  </v-container>
+</template>
+
+<script>
+export default {
+  props: {
+    user: {
+      type: Object,
+      default: () => {},
+      required: true
+    }
+  },
+  data() {
+    return {
+      rating: 3.1
+    }
+  },
+  computed: {
+    fullName() {
+      return `${this.user.last_name} ${this.user.first_name}`
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/mobile/SpeedDial.vue
+++ b/app/javascript/components/parts/mobile/SpeedDial.vue
@@ -1,0 +1,52 @@
+<template>
+  <v-speed-dial
+    v-model="fab"
+    bottom
+    fixed
+    right
+  >
+    <template #activator>
+      <v-btn
+        v-model="fab"
+        fab
+        bottom
+        right
+        dark
+        x-large
+        color="#EF5350"
+      >
+        <v-icon v-if="fab">
+          mdi-close
+        </v-icon>
+        <v-icon v-else>
+          mdi-account-circle
+        </v-icon>
+      </v-btn>
+    </template>
+    <v-btn
+      fab
+      dark
+      color="green"
+    >
+      <v-icon>mdi-pencil</v-icon>
+    </v-btn>
+    <v-btn
+      fab
+      dark
+      outlined
+      color="primary"
+    >
+      <v-icon>mdi-account-plus</v-icon>
+    </v-btn>
+  </v-speed-dial>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      fab: false
+    }
+  }
+}
+</script>

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -3,6 +3,7 @@ import store from "../store"
 
 import Top from "../components/pages/Top"
 import SignupLogin from "../components/pages/SignupLogin"
+import Mypage from "../components/pages/Mypage"
 
 const routes = [
   {
@@ -15,6 +16,12 @@ const routes = [
     name: "login",
     component: SignupLogin
   },
+  {
+    path: "/profile",
+    name: "profile",
+    component: Mypage,
+    meta: { requiredLogin: true }
+  }
 ]
 
 const router = new VueRouter({ mode: "history", routes })


### PR DESCRIPTION
## やったこと
プロフィールページ(マイページ)をざっくりと作成
プロフィールページをコンポーネントに分割

## やらないこと
APIを呼び出す処理
ログインユーザーと他のユーザーで表示させるものを分ける

## できるようになること（ユーザ目線）
プロフィールページ(マイページ)に遷移することができる

## できなくなること（ユーザ目線）
特になし

## 動作確認
プロフィールページがに遷移できることを確認
想定通りに表示されることを確認

## その他
特になし
