### PR TITLE
ログイン後にプロフィールページに遷移するように #10

### DIFF
--- a/app/javascript/components/globals/TheBreadCrumb.vue
+++ b/app/javascript/components/globals/TheBreadCrumb.vue
@@ -8,14 +8,14 @@
       <v-breadcrumbs-item
         :to="props.item.to"
         :disabled="props.item.disabled"
+        class="text-caption"
       >
         <span
           v-if="props.item.to !== '/'"
-          :class="$route.path === props.item.to ? 'text-caption black--text font-weight-bold' : 'text-caption'"
+          :class="$route.path === props.item.to ? 'black--text font-weight-bold' : ''"
         >{{ props.item.text }}</span>
         <span
           v-else
-          class="text-caption"
         ><v-icon
           size="18"
           class="mr-1"

--- a/app/javascript/components/parts/LoginForm.vue
+++ b/app/javascript/components/parts/LoginForm.vue
@@ -148,9 +148,10 @@ export default {
           email: this.email,
           password: this.password,
         })
-        await this.$store.dispatch("user/getCurrentUserFromAPI")
+        await this.$store.dispatch("user/getCurrentUser")
+        this.$router.push({ name: "profile" })
       } catch(err) {
-        if (err.response.data.key === 'inactive') {
+        if (err.response.data.key === "inactive") {
           return this.active = false
         }
         this.$refs.observer.setErrors(err.response.data)


### PR DESCRIPTION
## やったこと
ログイン後にプロフィールページに遷移するように修正

## やらないこと
特になし

## できるようになること（ユーザ目線）
ログインに成功したらプロフィールページに遷移する

## できなくなること（ユーザ目線）
特になし

## 動作確認
ログインに成功後プロフィールページに遷移することを確認

## その他
特になし
