### PR TITLE
リーグ構成に必要なテーブルを作成 #10

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,4 @@
+class Category < ApplicationRecord
+  belongs_to :league
+  has_many :groups
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,5 @@
+class Group < ApplicationRecord
+  belongs_to :category
+
+  validates :name, presence: true
+end

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -1,2 +1,5 @@
 class League < ApplicationRecord
+  has_many :categories
+
+  validates :name, presence: true
 end

--- a/db/migrate/20210607123544_create_leagues.rb
+++ b/db/migrate/20210607123544_create_leagues.rb
@@ -1,0 +1,9 @@
+class CreateLeagues < ActiveRecord::Migration[6.1]
+  def change
+    create_table :leagues do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210607150444_create_categories.rb
+++ b/db/migrate/20210607150444_create_categories.rb
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+      t.references :league, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210610083546_create_groups.rb
+++ b/db/migrate/20210610083546_create_groups.rb
@@ -1,0 +1,10 @@
+class CreateGroups < ActiveRecord::Migration[6.1]
+  def change
+    create_table :groups do |t|
+      t.string :name
+      t.references :category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_23_074713) do
+ActiveRecord::Schema.define(version: 2021_06_10_083546) do
+
+  create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "league_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["league_id"], name: "index_categories_on_league_id"
+  end
+
+  create_table "groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.bigint "category_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id"], name: "index_groups_on_category_id"
+  end
+
+  create_table "leagues", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "first_name", null: false
@@ -31,4 +53,6 @@ ActiveRecord::Schema.define(version: 2021_05_23_074713) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "categories", "leagues"
+  add_foreign_key "groups", "categories"
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :category do
+    name { "MyString" }
+    league { nil }
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :group do
+    name { "MyString" }
+    category { nil }
+  end
+end

--- a/spec/factories/leagues.rb
+++ b/spec/factories/leagues.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :league do
+    name { "MyString" }
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/league_spec.rb
+++ b/spec/models/league_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe League, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## やったこと
リーグ構成に必要なテーブルを作成
league・category・groupの三つのテーブル
league>category>groupの順になっているツリー構造

## やらないこと
リーグのデータの作成

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
特になし

## 動作確認
特になし

## その他
特になし
