### PR TITLE
プロフィル編集機能の実装 #5

### DIFF
--- a/app/controllers/api/v1/users/currents_controller.rb
+++ b/app/controllers/api/v1/users/currents_controller.rb
@@ -5,5 +5,18 @@ class Api::V1::Users::CurrentsController < Api::V1::BaseController
     render json: current_user
   end
 
-  def update; end
+  def update
+    current_user.assign_attributes(user_params)
+    if current_user.save
+      render json: current_user
+    else
+      render json: { errors: current_user.errors }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, :avatar, :email, :introduction)
+  end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -12,6 +12,6 @@ class Api::V1::UsersController < Api::V1::BaseController
   private
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :avatar, :email, :birth_date, :role, :introduction, :password)
+    params.require(:user).permit(:first_name, :last_name, :avatar, :email, :birth_date, :password)
   end
 end

--- a/app/javascript/components/globals/TheHeader.vue
+++ b/app/javascript/components/globals/TheHeader.vue
@@ -166,7 +166,7 @@ export default {
   computed: {
     ...mapGetters({ currentUser: "user/currentUser" }),
     fullName() {
-      return `${this.currentUser.last_name} ${this.currentUser.first_name}`
+      return `${this.currentUser.lastName} ${this.currentUser.firstName}`
     }
   },
   methods: {

--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -46,6 +46,11 @@
         :user="currentUser"
       />
     </div>
+    <the-profile-edit-dialog
+      ref="profileEditDialog"
+      v-bind.sync="userEdit"
+      @click-update="updateProfile"
+    />
   </div>
 </template>
 
@@ -55,13 +60,16 @@ import TheBreadCrumb from "../globals/TheBreadCrumb"
 import Profile from "../parts/Profile"
 import ReviewList from "../parts/ReviewList"
 import Information from "../parts/Information"
+import TheBreadCrumb from "../globals/TheBreadCrumb"
+import TheProfileEditDialog from "../parts/TheProfileEditDialog"
 
 export default {
   components: {
-    TheBreadCrumb,
     Profile,
     ReviewList,
-    Information
+    Information,
+    TheBreadCrumb,
+    TheProfileEditDialog,
   },
   data() {
     return {

--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -4,7 +4,12 @@
       :bread-crumbs="breadCrumbs"
     />
     <profile
+      ref="profile"
       :user="currentUser"
+      :user-edit="userEdit"
+      @click-edit="openEditDialog"
+      @click-introduction="userEdit = { ...currentUser }"
+      @click-update="updateIntroduction"
     />
     <div
       class="profile-tabs"
@@ -78,16 +83,9 @@ export default {
   },
   computed: {
     ...mapGetters({ currentUser: "user/currentUser" }),
-    fullName() {
-      return `${this.currentUser.last_name} ${this.currentUser.first_name}`
-    },
-    player() {
-      if (this.currentUser.role === "player") {
-        return true
-      } else {
-        return false
-      }
-    }
+  },
+  created() {
+    this.userEdit = { ...this.currentUser }
   },
   methods: {
     changeUserInformation() {
@@ -97,6 +95,23 @@ export default {
     changeReviewList() {
       this.reviewList = true
       this.userInformation = false
+    },
+    openEditDialog() {
+      this.userEdit = { ...this.currentUser }
+      this.$refs.profileEditDialog.open()
+    },
+    async updateIntroduction() {
+      await this.$store.dispatch("user/updateCurrentUser", this.userEdit)
+      this.$refs.profile.close()
+    },
+    async updateProfile() {
+      const user = await this.$store.dispatch("user/updateCurrentUser", this.userEdit)
+      if (!user) return this.$refs.profileEditDialog.dupEmail()
+      if (user.activation) {
+        this.$refs.profileEditDialog.close()
+      } else {
+        this.$refs.profileEditDialog.sendActivationEmail()
+      }
     }
   }
 }

--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -74,6 +74,7 @@ export default {
     return {
       userInformation: true,
       reviewList: false,
+      userEdit: {},
       breadCrumbs: [
         {
           text: "TOP",

--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -56,7 +56,6 @@
 
 <script>
 import { mapGetters } from "vuex"
-import TheBreadCrumb from "../globals/TheBreadCrumb"
 import Profile from "../parts/Profile"
 import ReviewList from "../parts/ReviewList"
 import Information from "../parts/Information"

--- a/app/javascript/components/parts/Profile.vue
+++ b/app/javascript/components/parts/Profile.vue
@@ -34,24 +34,14 @@
     <!-- 自己紹介文 -->
     <v-container class="px-4 pt-0">
       <v-row>
-        <v-col
-          cols="12"
-          lg="8"
-        >
-          <p
-            class="text-caption"
-            style="color: #616161;"
-          >
-            {{ user.introduction }}
-          </p>
-        </v-col>
-        <v-col
-          class="pl-10"
-          v-if="!$vuetify.breakpoint.mobile"
-          lg="4"
-        >
-          <profile-card />
-        </v-col>
+        <profile-introduction
+          ref="profileIntroduction"
+          :user="user"
+          v-bind.sync="userEdit"
+          @click-introduction="$emit('click-introduction')"
+          @click-update="$emit('click-update')"
+        />
+        <profile-card v-if="!$vuetify.breakpoint.mobile" />
       </v-row>
     </v-container>
   </div>
@@ -61,18 +51,30 @@
 import ProfileAction from "./ProfileAction"
 import ProfileTitle from "./ProfileTitle"
 import ProfileCard from "./ProfileCard"
+import ProfileIntroduction from './ProfileIntroduction.vue'
 
 export default {
   components: {
     ProfileAction,
     ProfileTitle,
     ProfileCard,
+    ProfileIntroduction
   },
   props: {
     user: {
       type: Object,
       default: () => {},
       required: true
+    },
+    userEdit: {
+      type: Object,
+      default: () => {},
+      required: true
+    }
+  },
+  methods: {
+    close() {
+      this.$refs.profileIntroduction.close()
     }
   }
 }

--- a/app/javascript/components/parts/ProfileAction.vue
+++ b/app/javascript/components/parts/ProfileAction.vue
@@ -2,12 +2,12 @@
   <div :style="$vuetify.breakpoint.mobile ? 'position: relative; top: 27px;' : ''">
     <!-- ログインユーザーの場合 -->
     <v-btn
-      v-if="!$vuetify.breakpoint.mobile"
       rounded
       class="font-weight-bold px-2 py-5 text-caption"
       outlined
       x-large
       color="primary"
+      @click="$emit('click-edit')"
     >
       <v-icon>
         mdi-pencil-outline

--- a/app/javascript/components/parts/ProfileAction.vue
+++ b/app/javascript/components/parts/ProfileAction.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div :style="$vuetify.breakpoint.mobile ? 'position: relative; top: 27px;' : ''">
     <!-- ログインユーザーの場合 -->
     <v-btn
       v-if="!$vuetify.breakpoint.mobile"
@@ -16,10 +16,9 @@
     </v-btn>
     <!-- 他のユーザーの場合 -->
     <!-- <template
-      v-if="!$vuetify.breakpoint.mobile"
     >
       <v-btn
-        class="mr-4"
+        class="mr-1"
         outlined
         color="primary"
         fab

--- a/app/javascript/components/parts/ProfileAction.vue
+++ b/app/javascript/components/parts/ProfileAction.vue
@@ -40,3 +40,15 @@
     </template> -->
   </div>
 </template>
+
+<script>
+export default {
+  props: {
+    user: {
+      type: Object,
+      default: () => {},
+      required: true
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/ProfileIntroduction.vue
+++ b/app/javascript/components/parts/ProfileIntroduction.vue
@@ -1,0 +1,110 @@
+<template>
+  <v-col
+    cols="12"
+    lg="8"
+  >
+    <template v-if="!form">
+      <p
+        class="text-caption"
+        style="color: #616161; overflow-wrap: break-word;"
+      >
+        {{ user.introduction }}
+        <v-btn
+          v-if="user.introduction"
+          small
+          text
+          depressed
+          color="primary"
+          @click="open"
+        >
+          編集
+        </v-btn>
+        <v-btn
+          v-else
+          text
+          depressed
+          color="primary"
+          @click="open"
+        >
+          自己紹介を追加
+        </v-btn>
+      </p>
+    </template>
+    <template v-if="form">
+      <ValidationObserver
+        ref="observer"
+        v-slot="{ handleSubmit }"
+      >
+        <v-card outlined>
+          <v-card-text class="py-0">
+            <v-form>
+              <ValidationProvider
+                v-slot="{ errors }"
+                rules="max:400"
+                name="自己紹介"
+              >
+                <v-textarea
+                  :value="introduction"
+                  counter="400"
+                  :error-messages="errors"
+                  @input="$emit('update:introduction', $event)"
+                />
+              </ValidationProvider>
+            </v-form>
+          </v-card-text>
+          <v-card-actions class="pt-0">
+            <v-spacer />
+            <v-btn
+              color="primary"
+              text
+              @click="close"
+            >
+              キャンセル
+            </v-btn>
+            <v-btn
+              color="primary"
+              text
+              @click="handleSubmit(clickUpdate)"
+            >
+              更新
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </ValidationObserver>
+    </template>
+  </v-col>
+</template>
+
+<script>
+export default {
+  props: {
+    user: {
+      type: Object,
+      default: () => {},
+      required: true
+    },
+    introduction: {
+      type: String,
+      default: "",
+      required: true
+    }
+  },
+  data() {
+    return {
+      form: false,
+    }
+  },
+  methods: {
+    open() {
+      this.form = true
+      this.$emit("click-introduction")
+    },
+    close() {
+      this.form = false
+    },
+    clickUpdate() {
+      this.$emit("click-update")
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/ProfileTitle.vue
+++ b/app/javascript/components/parts/ProfileTitle.vue
@@ -53,7 +53,7 @@ export default {
   },
   computed: {
     fullName() {
-      return `${this.user.last_name} ${this.user.first_name}`
+      return `${this.user.lastName} ${this.user.firstName}`
     }
   }
 }

--- a/app/javascript/components/parts/SignupDialog.vue
+++ b/app/javascript/components/parts/SignupDialog.vue
@@ -11,7 +11,7 @@
           @click="close"
         >
           <v-icon
-            v-if="registerSelect || sendActivationEmail"
+            v-if="registerSelect || sendEmail"
           >
             mdi-close
           </v-icon>
@@ -39,7 +39,7 @@
         />
 
         <send-activation-email
-          v-if="sendActivationEmail"
+          v-if="sendEmail"
           :email="email"
         >
           <template #resend>
@@ -95,7 +95,7 @@ export default {
       dialog: false,
       registerSelect: false,
       signupForm: false,
-      sendActivationEmail: false,
+      sendEmail: false,
       email: ""
     }
   },
@@ -117,7 +117,7 @@ export default {
     },
     showSendEmail(email) {
       this.signupForm = false
-      this.sendActivationEmail = true
+      this.sendEmail = true
       this.email = email
     },
     async resendEmail() {

--- a/app/javascript/components/parts/SignupDialog.vue
+++ b/app/javascript/components/parts/SignupDialog.vue
@@ -8,7 +8,7 @@
       <v-card>
         <v-btn
           icon
-          @click="closeDialog"
+          @click="close"
         >
           <v-icon
             v-if="registerSelect || sendActivationEmail"
@@ -104,7 +104,7 @@ export default {
       this.dialog = true
       this.registerSelect = true
     },
-    closeDialog() {
+    close() {
       if (this.signupForm === true) {
         this.signupForm = false
         return this.registerSelect = true

--- a/app/javascript/components/parts/TheProfileEditDialog.vue
+++ b/app/javascript/components/parts/TheProfileEditDialog.vue
@@ -1,0 +1,249 @@
+<template>
+  <v-dialog
+    v-model="dialog"
+    width="550"
+    :persistent="true"
+    scrollable
+  >
+    <v-card>
+      <v-btn
+        icon
+        @click="close"
+      >
+        <v-icon>
+          mdi-close
+        </v-icon>
+      </v-btn>
+      <v-card-title
+        class="pt-0 font-weight-bold justify-center"
+      >
+        プロフィール編集
+      </v-card-title>
+      <v-divider />
+      <v-card-text
+        v-if="form"
+        :style="$vuetify.breakpoint.mobile ? 'height: 450px' : ''"
+        :class="$vuetify.breakpoint.mobile ? 'px-2' : ''"
+      >
+        <ValidationObserver
+          ref="observer"
+          v-slot="{ handleSubmit }"
+        >
+          <v-form>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="12"
+                  class="pb-0"
+                >
+                  <span
+                    class="font-weight-bold text-h6"
+                    style="color: black;"
+                  >
+                    プロフィール写真
+                  </span>
+                </v-col>
+                <v-col
+                  align="center"
+                  cols="12"
+                  class="mt-2 pb-3"
+                >
+                  <v-avatar
+                    size="140"
+                    style="cursor: pointer;"
+                    @click="$refs.fileInput.$refs.input.click()"
+                  >
+                    <v-img
+                      :src="avatar"
+                    />
+                  </v-avatar>
+                  <br>
+                  <v-file-input
+                    ref="fileInput"
+                    style="display: none;"
+                  />
+                </v-col>
+                <v-col cols="12">
+                  <span
+                    class="font-weight-bold text-h6"
+                    style="color: black;"
+                  >
+                    基本情報
+                  </span>
+                  <br>
+                  <span class="text-caption font-weight-bold">*メールアドレス変更時には再度アカウント認証が必要になります。</span>
+                </v-col>
+                <v-col
+                  cols="6"
+                >
+                  <ValidationProvider
+                    v-slot="{ errors }"
+                    name="性"
+                    rules="required|max:30"
+                  >
+                    <v-text-field
+                      :value="lastName"
+                      outlined
+                      dense
+                      label="性"
+                      required
+                      :error-messages="errors"
+                      @input="$emit('update:lastName', $event)"
+                    />
+                  </ValidationProvider>
+                </v-col>
+                <v-col
+                  cols="6"
+                >
+                  <ValidationProvider
+                    v-slot="{ errors }"
+                    name="名"
+                    rules="required|max:30"
+                  >
+                    <v-text-field
+                      :value="firstName"
+                      outlined
+                      dense
+                      label="名"
+                      required
+                      :error-messages="errors"
+                      @input="$emit('update:firstName', $event)"
+                    />
+                  </ValidationProvider>
+                </v-col>
+                <v-col
+                  class="pt-0"
+                  cols="12"
+                >
+                  <ValidationProvider
+                    v-slot="{ errors }"
+                    name="メールアドレス"
+                    vid="email"
+                    :rules="{ required: true, formFormat: /^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/i }"
+                  >
+                    <v-text-field
+                      :value="email"
+                      outlined
+                      dense
+                      label="メールアドレス"
+                      required
+                      :error-messages="errors"
+                      @input="$emit('update:email', $event)"
+                    />
+                  </ValidationProvider>
+                </v-col>
+                <v-col
+                  class="pt-0"
+                  cols="12"
+                >
+                  <ValidationProvider
+                    v-slot="{ errors }"
+                    rules="max:400"
+                    name="自己紹介"
+                  >
+                    <v-textarea
+                      :value="introduction"
+                      outlined
+                      dense
+                      label="自己紹介"
+                      counter="400"
+                      :error-messages="errors"
+                      @input="$emit('update:introduction', $event)"
+                    />
+                  </ValidationProvider>
+                </v-col>
+                <v-col
+                  cols="12"
+                  class="pt-0"
+                >
+                  <v-btn
+                    color="#3949AB"
+                    class="font-weight-bold"
+                    large
+                    dark
+                    block
+                    depressed
+                    @click="handleSubmit(clickUpdate)"
+                  >
+                    更新する
+                  </v-btn>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-form>
+        </ValidationObserver>
+      </v-card-text>
+      <send-activation-email
+        v-if="sendEmail"
+        :email="email"
+      />
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import SendActivationEmail from "./SendActivationEmail"
+
+export default {
+  components : {
+    SendActivationEmail
+  },
+  props: {
+    avatar: {
+      type: String,
+      default: "",
+      required: true
+    },
+    lastName: {
+      type: String,
+      default: "",
+      required: true
+    },
+    firstName: {
+      type: String,
+      default: "",
+      required: true
+    },
+    email: {
+      type: String,
+      default: "",
+      required: true
+    },
+    introduction: {
+      type: String,
+      default: "",
+      required: true
+    }
+  },
+  data() {
+    return {
+      dialog: false,
+      form: false,
+      sendEmail: false
+    }
+  },
+  methods: {
+    open() {
+      this.dialog = true
+      this.form = true
+    },
+    close() {
+      this.dialog = false
+      this.sendEmail = false
+      this.$emit("click-close")
+    },
+    clickUpdate() {
+      this.$emit("click-update")
+    },
+    sendActivationEmail() {
+      this.form = false
+      this.sendEmail = true
+    },
+    dupEmail() {
+      this.$refs.observer.setErrors({
+        email: ["このメールアドレスは既に使用されています"]
+      })
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/TheResendActivationEmailDialog.vue
+++ b/app/javascript/components/parts/TheResendActivationEmailDialog.vue
@@ -20,7 +20,7 @@
       </v-card-title>
       <v-divider />
       <v-card-text
-        v-if="emailForm"
+        v-if="form"
         class="pt-6 pb-0"
       >
         <ValidationObserver
@@ -73,7 +73,7 @@
         </ValidationObserver>
       </v-card-text>
       <send-activation-email
-        v-if="sendActivationEmail"
+        v-if="sendEmail"
         :email="email"
       />
     </v-card>
@@ -91,14 +91,14 @@ export default {
     return {
       dialog: false,
       email: "",
-      emailForm: false,
-      sendActivationEmail: false
+      form: false,
+      sendEmail: false
     }
   },
   methods: {
     open() {
       this.dialog = true
-      this.emailForm = true
+      this.form = true
     },
     closeDialog() {
       Object.assign(this.$data, this.$options.data())
@@ -108,8 +108,8 @@ export default {
         await this.$axios.post("/api/v1/account_activations", {
           email: this.email
         })
-        this.emailForm = false
-        this.sendActivationEmail = true
+        this.form = false
+        this.sendEmail = true
       } catch(err) {
         this.$refs.observer.setErrors(err.response.data)
       }

--- a/app/javascript/store/user.js
+++ b/app/javascript/store/user.js
@@ -31,6 +31,17 @@ const actions = {
       return null
     }
   },
+  async updateCurrentUser({ commit }, user) {
+    try {
+      const response = await axios.patch("/api/v1/users/current", {
+        user: user
+      })
+      commit("setCurrentUser", response.data)
+      return response.data
+    } catch(err) {
+      return null
+    }
+  },
   async logout({ commit }) {
     await axios.delete("/api/v1/logout")
     commit("setCurrentUser", null)


### PR DESCRIPTION
## やったこと
プロフィール編集機能の実装
性、名、メールアドレス、自己紹介を編集できるようにする

## やらないこと
アバターとパスワードの変更

## できるようになること（ユーザ目線）
プロフィール編集で性、名、メールアドレス、自己紹介を変更できるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
性、名、メールアドレス、自己紹介を編集できることを確認

## その他
特になし
