### PR TITLE
フォームの背景色を修正 #5

### DIFF
--- a/app/javascript/components/parts/LoginForm.vue
+++ b/app/javascript/components/parts/LoginForm.vue
@@ -20,7 +20,7 @@
                 v-model="email"
                 label="メールアドレス"
                 outlined
-                background-color="#ECEFF1"
+                background-color="#F2F4F8"
                 required
                 :error-messages="errors"
               />
@@ -43,7 +43,7 @@
                 label="パスワード"
                 outlined
                 counter
-                background-color="#ECEFF1"
+                background-color="#F2F4F8"
                 required
                 :error-messages="errors"
                 @click:append="show = !show"

--- a/app/javascript/components/parts/SignupDialogForm.vue
+++ b/app/javascript/components/parts/SignupDialogForm.vue
@@ -24,7 +24,7 @@
                   dense
                   label="性"
                   placeholder="例）中山"
-                  background-color="#ECEFF1"
+                  background-color="#F2F4F8"
                   required
                   :error-messages="errors"
                 />
@@ -45,7 +45,7 @@
                   dense
                   placeholder="例）太郎"
                   label="名"
-                  background-color="#ECEFF1"
+                  background-color="#F2F4F8"
                   required
                   :error-messages="errors"
                 />
@@ -75,7 +75,7 @@
                       dense
                       readonly
                       v-bind="attrs"
-                      background-color="#ECEFF1"
+                      background-color="#F2F4F8"
                       required
                       :error-messages="errors"
                       v-on="on"
@@ -112,7 +112,7 @@
                   dense
                   label="メールアドレス"
                   placeholder="例）famo0123@example.com"
-                  background-color="#ECEFF1"
+                  background-color="#F2F4F8"
                   required
                   :error-messages="errors"
                 />
@@ -138,7 +138,7 @@
                   outlined
                   dense
                   counter
-                  background-color="#ECEFF1"
+                  background-color="#F2F4F8"
                   required
                   :error-messages="errors"
                   @click:append="show = !show"

--- a/app/javascript/components/parts/TheProfileEditDialog.vue
+++ b/app/javascript/components/parts/TheProfileEditDialog.vue
@@ -87,7 +87,7 @@
                       dense
                       label="性"
                       required
-                      background-color="#ECEFF1"
+                      background-color="#F2F4F8"
                       :error-messages="errors"
                       @input="$emit('update:lastName', $event)"
                     />
@@ -107,7 +107,7 @@
                       dense
                       label="名"
                       required
-                      background-color="#ECEFF1"
+                      background-color="#F2F4F8"
                       :error-messages="errors"
                       @input="$emit('update:firstName', $event)"
                     />
@@ -129,7 +129,7 @@
                       dense
                       label="メールアドレス"
                       required
-                      background-color="#ECEFF1"
+                      background-color="#F2F4F8"
                       :error-messages="errors"
                       @input="$emit('update:email', $event)"
                     />


### PR DESCRIPTION
## やったこと
フォームの背景色を修正
色を薄い青色に変更(#F2F4F8)

## やらないこと
特になし

## できるようになること（ユーザ目線）
フォームを薄くしたので入力した文字が見やすくなる

## できなくなること（ユーザ目線）
特になし

## 動作確認
想定通りに表示されることを確認

## その他
特になし
