### PR TITLE
dependentオプションを指定

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,4 @@
 class Category < ApplicationRecord
   belongs_to :league
-  has_many :groups
+  has_many :groups, dependent: :restrict_with_exception
 end

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -1,5 +1,5 @@
 class League < ApplicationRecord
-  has_many :categories
+  has_many :categories, dependent: :restrict_with_exception
 
   validates :name, presence: true
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,3 +1,3 @@
 class Prefecture < ApplicationRecord
-  has_many :teams, dependent: :restrict_with_error
+  has_many :teams, dependent: :restrict_with_exception
 end


### PR DESCRIPTION
## やったこと
子レコードがある場合に親レコードを削除できないようにdependent: :restrict_with_exceptionを指定
:restrict_with_exceptionは子レコードがある場合は ActiveRecord::DeleteRestrictionError が発生する。（引き留めパターン）

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
特になし

## 動作確認
子レコードがある場合に親レコードを削除できないのを確認

## その他
参考サイト
https://qiita.com/jnchito/items/3456ce734ef41d216ecd
