### PR TITLE
チームに関係する処理を実装 #5

### DIFF
--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::TeamsController < ApplicationController
+  def index
+    teams = Team.all
+    render json: teams, each_serializer: TeamSerializer
+  end
+
+  def create
+    team = Team.new(team_params)
+    if team.save
+      head :created
+    else
+      render json: { errors: team.errors }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def team_params
+    params.require(:team).permit(:name, :kind, :prefecture_id)
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,8 @@
+class Team < ApplicationRecord
+  belongs_to :prefecture
+
+  validates :name, presence: true, uniqueness: { scope: :prefecture }
+  validates :kind, presence: true
+
+  enum kind: { high_school: 0, youth: 1 }
+end

--- a/app/serializers/team_serializer.rb
+++ b/app/serializers/team_serializer.rb
@@ -1,0 +1,3 @@
+class TeamSerializer < ActiveModel::Serializer
+  attributes :id, :name, :kind, :prefecture_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
       resources :leagues, only: %i[index]
       resources :categories, only: %i[index]
       resources :groups, only: %i[index]
+      resources :prefectures, only: %i[index]
+      resources :teams, only: %i[index create]
       resources :account_activations, only: %i[create edit]
       post '/login', to: 'user_sessions#create'
       delete '/logout', to: 'user_sessions#destroy'

--- a/db/migrate/20210617180257_create_teams.rb
+++ b/db/migrate/20210617180257_create_teams.rb
@@ -1,0 +1,12 @@
+class CreateTeams < ActiveRecord::Migration[6.1]
+  def change
+    create_table :teams do |t|
+      t.string :name, null: false
+      t.integer :kind, null: false, default: 0
+      t.references :prefecture, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :teams, [:name, :prefecture_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_17_145828) do
+ActiveRecord::Schema.define(version: 2021_06_17_180257) do
 
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -40,6 +40,16 @@ ActiveRecord::Schema.define(version: 2021_06_17_145828) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "teams", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "kind", default: 0, null: false
+    t.bigint "prefecture_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name", "prefecture_id"], name: "index_teams_on_name_and_prefecture_id", unique: true
+    t.index ["prefecture_id"], name: "index_teams_on_prefecture_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
@@ -61,4 +71,5 @@ ActiveRecord::Schema.define(version: 2021_06_17_145828) do
 
   add_foreign_key "categories", "leagues"
   add_foreign_key "groups", "categories"
+  add_foreign_key "teams", "prefectures"
 end

--- a/spec/models/prefecture_spec.rb
+++ b/spec/models/prefecture_spec.rb
@@ -1,4 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Prefecture, type: :model do
+  describe 'association' do
+    it 'has_many :teams :restrict_with_exception' do
+      is_expected.to have_many(:teams).dependent(:restrict_with_exception)
+    end
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Team, type: :model do
+  describe 'assocation' do
+    it 'belongs_to :prefecture' do
+      is_expected.to belong_to(:prefecture)
+    end
+  end
+
+  describe 'presence' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:kind) }
+  end
+end

--- a/spec/requests/api/v1/teams_spec.rb
+++ b/spec/requests/api/v1/teams_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Teams", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/api/v1/teams/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## やったこと
teamsテーブルの作成
teamsコントローラの作成
チーム一覧を返す処理とチーム作成の処理を実装
必要なパスを追記
チーム名と都道府県で一意制約をかける

## やらないこと
特になし

## できるようになること（ユーザ目線）
チームを作成できるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
チームが作成できることを確認
同じチームを作成できないことを確認

## その他
特になし
