### PR TITLE
修正 #5

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,4 @@
 class Group < ApplicationRecord
   belongs_to :category
+  has_many :profiles
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,5 +1,6 @@
 class Team < ApplicationRecord
   belongs_to :prefecture
+  has_many :profiles
 
   validates :name, presence: true, uniqueness: { scope: :prefecture }
   validates :kind, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   before_update :setup_activation_attributes, if: -> { email_changed? }
   after_update :send_activation_needed_email!, if: -> { previous_changes['email'].present? }
 
-  has_one :profile
+  has_one :profile, dependent: :destroy
 
   authenticates_with_sorcery!
 

--- a/db/migrate/20210619200252_create_profiles.rb
+++ b/db/migrate/20210619200252_create_profiles.rb
@@ -3,7 +3,7 @@ class CreateProfiles < ActiveRecord::Migration[6.1]
     create_table :profiles do |t|
       t.string :position, null: false
       t.integer :uniform_number, null: false
-      t.string :career, null: false
+      t.string :career
       t.references :user, null: false, fereign_key: true
       t.references :group, null: false, foreign_key: true
       t.references :team, null: false, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 2021_06_19_200252) do
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "position", null: false
     t.integer "uniform_number", null: false
-    t.string "career", null: false
+    t.string "career"
     t.bigint "user_id", null: false
     t.bigint "group_id", null: false
     t.bigint "team_id", null: false


### PR DESCRIPTION
## やったこと
teamテーブルのcareerカラムのnullを許容
ユーザーが削除されたらプロフィールも削除されるように設定
グループとプロフィールのアソシエーションを追加
チームとプロフィールのアソシエーションを追加

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
特になし

## 動作確認
careerのnullが許容されることを確認
ユーザーが削除されたらプロフィールも削除されることを確認
プロフィールにグループとチームのアソシエーションが追加されていることを確認

## その他
特になし
