### PR TITLE
カラムの追加と名前の変更 #5

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,5 +4,6 @@ class Profile < ApplicationRecord
   belongs_to :user
 
   validates :position, presence: true
-  validates :uniform_number, presence: true
+  validates :official_number, presence: true, numericality: true
+  validates :practice_number, numericality: true, allow_nil: true
 end

--- a/db/migrate/20210621184539_rename_uniform_number_column_to_profiles.rb
+++ b/db/migrate/20210621184539_rename_uniform_number_column_to_profiles.rb
@@ -1,0 +1,5 @@
+class RenameUniformNumberColumnToProfiles < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :profiles, :uniform_number, :official_number
+  end
+end

--- a/db/migrate/20210621184820_add_practice_number_to_profiles.rb
+++ b/db/migrate/20210621184820_add_practice_number_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddPracticeNumberToProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :profiles, :practice_number, :integer, after: :official_number
+  end
+end

--- a/db/migrate/20210621185549_remove_career_from_profiles.rb
+++ b/db/migrate/20210621185549_remove_career_from_profiles.rb
@@ -1,0 +1,5 @@
+class RemoveCareerFromProfiles < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :profiles, :career, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_19_200252) do
+ActiveRecord::Schema.define(version: 2021_06_21_185549) do
 
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -42,8 +42,8 @@ ActiveRecord::Schema.define(version: 2021_06_19_200252) do
 
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "position", null: false
-    t.integer "uniform_number", null: false
-    t.string "career"
+    t.integer "official_number", null: false
+    t.integer "practice_number"
     t.bigint "user_id", null: false
     t.bigint "group_id", null: false
     t.bigint "team_id", null: false


### PR DESCRIPTION
## やったこと
ユニフォームの番号を公式戦と練習試合で登録できるように修正
元々のカラムを公式戦用にし、新しく練習試合でのカラムを追加
練習用は必須ではない

## やらないこと
特になし

## できるようになること（ユーザ目線）
公式戦と練習試合での背番号を登録できるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
公式戦、練習の二つのカラムがプロフィールに存在することを確認

## その他
特になし
