### PR TITLE
profiles_controllerの作成 #5

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,18 @@
+class Api::V1::ProfilesController < ApplicationController
+  before_action :required_login, only: %i[create show]
+
+  def create
+    profile = current_user.build_profile(profile_params)
+    if profile.save
+      render json: profile, status: :created
+    else
+      render json: { errors: profile.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def update; end
+
+  def profile_params
+    params.require(:profile).permit(:position, :official_number, :practice_number, :group_id, :team_id)
+  end
+end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -1,0 +1,3 @@
+class ProfileSerializer < ActiveModel::Serializer
+  attributes :id, :position, :official_number, :practice_number, :team_id, :group_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
           end
         end
       end
+      resource :profiles, only: %i[create update]
       resources :leagues, only: %i[index]
       resources :prefecture_teams, only: %i[index]
       resources :teams, only: %i[create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
           end
         end
       end
-      resource :profiles, only: %i[create update]
+      resource :profile, only: %i[create update]
       resources :leagues, only: %i[index]
       resources :prefecture_teams, only: %i[index]
       resources :teams, only: %i[create]


### PR DESCRIPTION
## やったこと
profiles_controllerの作成
profiles_serializerの作成
profilesのパスを追加(create, update)

## やらないこと
updateの処理の実装

## できるようになること（ユーザ目線）
プロフィールを作成できるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
api/v1/profileにpostするとプロフィールを作成できることを確認
serializerで指定されたattributesをレスポンスで返却することを確認

## その他
特になし
