### PR TITLE
エラーメッセージのカスタマイズ #5

### DIFF
--- a/app/javascript/plugins/vee-validate.js
+++ b/app/javascript/plugins/vee-validate.js
@@ -1,5 +1,5 @@
 import { ValidationObserver, ValidationProvider, extend, setInteractionMode } from 'vee-validate'
-import { required, max, min } from 'vee-validate/dist/rules';
+import { required, max, min, numeric } from 'vee-validate/dist/rules';
 
 setInteractionMode("eager");
 
@@ -16,6 +16,11 @@ extend("max", {
 extend("min", {
   ...min,
   message: "{_field_}は{length}文字以上で入力してください"
+})
+
+extend("numeric", {
+  ...numeric,
+  message: "{_field_}は数字のみ入力可能です"
 })
 
 extend("formFormat", {

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -41,14 +41,27 @@ ja:
         category: カテゴリ
     errors:
       models:
-        user:
+        profile:
           attributes:
-            email:
-              taken: この%{attribute}はすでに存在します
+            group:
+              required: 選択して下さい
+            team:
+              required: "%{attribute}を選択して下さい"
+            position:
+              blank: "%{attribute}を選択して下さい"
         team:
           attributes:
-            name:
-              taken: この%{attribute}はすでに存在します
+            prefecture:
+              required: "%{attribute}を選択して下さい"
+            kind:
+              blank: "選択して下さい"
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      blank: "%{attribute}は必須項目です"
+      taken: この%{attribute}は既に存在します
+      too_long: "%{attribute}は%{count}文字以内で入力してください"
+      too_short: "%{attribute}は%{count}文字以上で入力してください"
   enums:
     user:
       role:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,23 +22,23 @@ ja:
         position: ポジション
         uniform_number: 背番号
         career: 経歴
-        user_id: ユーザー
-        team_id: チーム
-        group_id: グループ
+        user: ユーザー
+        team: チーム
+        group: グループ
       prefecture:
         name: 都道府県名
       team:
         name: チーム名
         kind: 種類
-        prefecture_id: 都道府県
+        prefecture: 都道府県
       league:
         name: リーグ名
       category:
         name: カテゴリ名
-        league_id: リーグ
+        league: リーグ
       group:
         name: グループ名
-        category_id: カテゴリ
+        category: カテゴリ
     errors:
       models:
         user:

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
       it 'エラーメッセージを返す' do
         post '/api/v1/users', headers: @header, params: { user: { email: user.email } }
         expect(response.status).to eq(422)
-        expect(json['errors']['email']).to include('このメールアドレスはすでに存在します')
+        expect(json['errors']['email']).to include('このメールアドレスは既に存在します')
       end
     end
   end


### PR DESCRIPTION
## やったこと
railsのエラーメッセージのカスタマイズ
vee-validateのエラーにnumeric(数字のみ許可)を追加

## やらないこと
特になし

## できるようになること（ユーザ目線）
エラーメッセージがわかりやすくなる

## できなくなること（ユーザ目線）
特になし

## 動作確認
想定通りのエラーメッセージが表示されることを確認

## その他
特になし
