### PR TITLE
選手編集ダイアログの作成 #5

### DIFF
--- a/app/controllers/api/v1/prefecture_teams_controller.rb
+++ b/app/controllers/api/v1/prefecture_teams_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::PrefecturesTeamsController < ApplicationController
+class Api::V1::PrefectureTeamsController < ApplicationController
   def index
     prefectures = Prefecture.preload(:teams)
     render json: prefectures, each_serializer: PrefectureSerializer

--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -7,6 +7,7 @@
       ref="profile"
       :user="currentUser"
       :user-edit="userEdit"
+      @click-player="$refs.playerDialog.open()"
       @click-edit="openEditDialog"
       @click-introduction="userEdit = { ...currentUser }"
       @click-update="updateIntroduction"
@@ -51,6 +52,9 @@
       v-bind.sync="userEdit"
       @click-update="updateProfile"
     />
+    <the-player-dialog
+      ref="playerDialog"
+    />
   </div>
 </template>
 
@@ -60,6 +64,7 @@ import Profile from "../parts/Profile"
 import ReviewList from "../parts/ReviewList"
 import Information from "../parts/Information"
 import TheBreadCrumb from "../globals/TheBreadCrumb"
+import ThePlayerDialog from "../parts/ThePlayerDialog"
 import TheProfileEditDialog from "../parts/TheProfileEditDialog"
 
 export default {
@@ -68,6 +73,7 @@ export default {
     ReviewList,
     Information,
     TheBreadCrumb,
+    ThePlayerDialog,
     TheProfileEditDialog,
   },
   data() {

--- a/app/javascript/components/parts/Profile.vue
+++ b/app/javascript/components/parts/Profile.vue
@@ -41,7 +41,10 @@
           @click-introduction="$emit('click-introduction')"
           @click-update="$emit('click-update')"
         />
-        <profile-card v-if="!$vuetify.breakpoint.mobile" />
+        <profile-card
+          v-if="!$vuetify.breakpoint.mobile"
+          @click-player="$emit('click-player')"
+        />
       </v-row>
     </v-container>
   </div>

--- a/app/javascript/components/parts/ProfileCard.vue
+++ b/app/javascript/components/parts/ProfileCard.vue
@@ -1,34 +1,31 @@
 <template>
-  <v-card outlined>
-    <v-simple-table dense>
-      <template #default>
-        <tbody>
-          <tr
-            v-for="item in desserts"
-            :key="item.name"
-          >
-            <td
-              class="pr-0"
-            >
-              <span
-                class="font-weight-bold"
-                style="font-size: 10px"
-              >{{ item.name }}</span>
-            </td>
-            <td
-              align="end"
-              class="pl-0"
-            >
-              <span
-                class="font-weight-bold"
-                style="font-size: 10px"
-              >{{ item.calories }}</span>
-            </td>
-          </tr>
-        </tbody>
-      </template>
-    </v-simple-table>
-  </v-card>
+  <v-col
+    class="pl-10"
+    lg="4"
+  >
+    <v-card
+      outlined
+    >
+      <v-simple-table dense>
+        <template #default>
+          <tbody>
+            <template>
+              <v-col align="center">
+                <v-btn
+                  right
+                  text
+                  color="primary"
+                  @click="$emit('click-player')"
+                >
+                  選手情報追加
+                </v-btn>
+              </v-col>
+            </template>
+          </tbody>
+        </template>
+      </v-simple-table>
+    </v-card>
+  </v-col>
 </template>
 
 <script>

--- a/app/javascript/components/parts/ProfileCard.vue
+++ b/app/javascript/components/parts/ProfileCard.vue
@@ -27,35 +27,3 @@
     </v-card>
   </v-col>
 </template>
-
-<script>
-export default {
-  data() {
-    return {
-      rating: 3.1,
-      desserts: [
-          {
-            name: "所属",
-            calories: "川崎フロンターレU18",
-          },
-          {
-            name: "ポジション",
-            calories: "MF",
-          },
-          {
-            name: "背番号",
-            calories: 10,
-          },
-        ],
-    }
-  },
-}
-</script>
-
-<style scoped>
-  .v-data-table
-    tbody
-    tr:hover:not(.v-data-table__expanded__content) {
-    background: #ffffff !important;
-  }
-</style>

--- a/app/javascript/components/parts/SignupDialogForm.vue
+++ b/app/javascript/components/parts/SignupDialogForm.vue
@@ -198,9 +198,7 @@ export default {
         this.signupForm = false
         this.$emit("create-user", this.user.email)
       } catch(err) {
-        this.$refs.observer.setErrors({
-          email: ["このメールアドレスは既に使用されています"]
-        })
+        this.$refs.observer.setErrors(err.response.data.errors)
       }
     }
   }

--- a/app/javascript/components/parts/ThePlayerDialog.vue
+++ b/app/javascript/components/parts/ThePlayerDialog.vue
@@ -1,0 +1,372 @@
+<template>
+  <v-dialog
+    v-model="dialog"
+    width="550"
+    :persistent="true"
+    scrollable
+  >
+    <v-card v-if="registerPlayer">
+      <v-btn
+        icon
+        @click="close"
+      >
+        <v-icon>
+          mdi-close
+        </v-icon>
+      </v-btn>
+      <v-card-title
+        class="pt-0 font-weight-bold justify-center text-h5"
+      >
+        選手情報登録
+      </v-card-title>
+      <v-divider />
+      <v-card-text
+        :style="$vuetify.breakpoint.mobile ? 'height: 450px' : ''"
+      >
+        <ValidationObserver
+          ref="observer"
+          v-slot="{ handleSubmit }"
+        >
+          <v-form ref="form">
+            <v-container>
+              <v-row>
+                <!-- チーム選択 -->
+                <v-col
+                  class="mt-3"
+                  cols="12"
+                >
+                  <span
+                    class="font-weight-bold text-h6 black--text"
+                  >
+                    所属チーム
+                  </span>
+                  <br>
+                  <span
+                    class="font-weight-bold text-caption"
+                  >
+                    *所属チームが見つからない場合は
+                    <span
+                      class="red--text"
+                      style="cursor: pointer;"
+                      @click="changeForm"
+                    >
+                      こちら
+                    </span>
+                    からチームを登録してください。
+                  </span>
+                </v-col>
+                <v-col
+                  cols="12"
+                  class="pt-0"
+                >
+                  <v-select
+                    v-model="prefecture"
+                    outlined
+                    dense
+                    label="都道府県"
+                    :items="prefectures"
+                    item-value="id"
+                    item-text="name"
+                    background-color="#F2F4F8"
+                  />
+                </v-col>
+                <v-col
+                  v-if="prefecture"
+                  cols="12"
+                  class="pt-0"
+                >
+                  <ValidationProvider
+                    v-slot="{ errors }"
+                    rules="required"
+                    name="チーム"
+                    vid="team"
+                  >
+                    <v-autocomplete
+                      v-model="profile.teamId"
+                      no-data-text="チームが見つかりません"
+                      outlined
+                      dense
+                      required
+                      label="チーム"
+                      :items="filterTeams"
+                      item-value="id"
+                      item-text="name"
+                      background-color="#F2F4F8"
+                      :error-messages="errors"
+                    />
+                  </ValidationProvider>
+                </v-col>
+                <!-- リーグ選択 -->
+                <v-col
+                  class="pt-0"
+                  cols="12"
+                >
+                  <span
+                    class="font-weight-bold text-h6 black--text"
+                  >
+                    所属リーグ
+                  </span>
+                </v-col>
+                <v-col
+                  cols="12"
+                  class="pt-0"
+                >
+                  <v-select
+                    v-model="league"
+                    outlined
+                    dense
+                    label="リーグ"
+                    :items="leagues"
+                    item-value="id"
+                    item-text="name"
+                    background-color="#F2F4F8"
+                    @click="category = ''"
+                  />
+                </v-col>
+                <v-col
+                  v-if="league"
+                  cols="12"
+                  class="pt-0"
+                >
+                  <ValidationProvider
+                    v-slot="{ errors }"
+                    rules="required"
+                    name="カテゴリ"
+                    vid="group"
+                  >
+                    <v-select
+                      v-model="category"
+                      outlined
+                      dense
+                      required
+                      label="カテゴリ"
+                      :items="filterCategories"
+                      item-value="id"
+                      item-text="name"
+                      background-color="#F2F4F8"
+                      :error-messages="errors"
+                      @change="setGroupId"
+                    />
+                  </ValidationProvider>
+                </v-col>
+                <v-col
+                  v-if="category && filterGroups.length !== 1"
+                  cols="12"
+                  class="pt-0"
+                >
+                  <ValidationProvider
+                    v-slot="{ errors }"
+                    rules="required"
+                    name="グループ"
+                    vid="group"
+                  >
+                    <v-select
+                      v-model="profile.groupId"
+                      outlined
+                      dense
+                      required
+                      label="グループ"
+                      :items="filterGroups"
+                      item-value="id"
+                      item-text="name"
+                      background-color="#F2F4F8"
+                      :error-messages="errors"
+                    />
+                  </ValidationProvider>
+                </v-col>
+                <!-- ポジション選択 -->
+                <v-col
+                  class="pt-0"
+                  cols="12"
+                >
+                  <span
+                    class="font-weight-bold text-h6 black--text"
+                  >
+                    ポジション
+                  </span>
+                </v-col>
+                <v-col
+                  cols="12"
+                  class="pt-0"
+                >
+                  <ValidationProvider
+                    v-slot="{ errors }"
+                    rules="required"
+                    name="ポジション"
+                    vid="position"
+                  >
+                    <v-select
+                      v-model="profile.position"
+                      background-color="#F2F4F8"
+                      outlined
+                      dense
+                      required
+                      label="ポジション"
+                      :items="positions"
+                      :error-messages="errors"
+                    />
+                  </ValidationProvider>
+                </v-col>
+                <!-- 背番号 -->
+                <v-col
+                  class="pt-0"
+                  cols="12"
+                >
+                  <span
+                    class="font-weight-bold text-h6 black--text"
+                  >
+                    背番号
+                  </span>
+                </v-col>
+                <v-col
+                  cols="12"
+                  class="pt-0"
+                >
+                  <ValidationProvider
+                    v-slot="{ errors }"
+                    rules="required|numeric"
+                    name="公式戦"
+                    vid="official_number"
+                  >
+                    <v-text-field
+                      v-model="profile.officialNumber"
+                      label="公式戦"
+                      background-color="#F2F4F8"
+                      outlined
+                      dense
+                      required
+                      hint="公式戦での背番号を入力して下さい"
+                      persistent-hint
+                      type="number"
+                      :error-messages="errors"
+                    />
+                  </ValidationProvider>
+                </v-col>
+                <v-col
+                  cols="12"
+                  class="pt-0"
+                >
+                  <v-btn
+                    color="#3949AB"
+                    class="font-weight-bold"
+                    large
+                    dark
+                    block
+                    depressed
+                    @click="handleSubmit(sendPlayerData)"
+                  >
+                    登録する
+                  </v-btn>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-form>
+        </ValidationObserver>
+      </v-card-text>
+    </v-card>
+    <the-player-dialog-team
+      v-if="registerTeam"
+      :prefectures="prefectures"
+      @click-back="changeForm"
+      @create-team="pushTeam"
+    />
+  </v-dialog>
+</template>
+
+<script>
+import ThePlayerDialogTeam from "./ThePlayerDialogTeam"
+
+export default {
+  components : {
+    ThePlayerDialogTeam
+  },
+  data() {
+    return {
+      dialog: false,
+      registerTeam: false,
+      registerPlayer: false,
+      leagues: [],
+      prefectures: [],
+      profile: {
+        position: "",
+        officialNumber: "",
+        groupId: "",
+        teamId: "",
+      },
+      league: "",
+      category: "",
+      prefecture: "",
+      positions: [ "GK", "DF", "MF", "FW" ]
+    }
+  },
+  computed: {
+    filterCategories() {
+      return this.leagues.find(league => {
+        return league.id === this.league
+      }).categories
+    },
+    filterGroups() {
+      return this.filterCategories.find(category => {
+        return category.id === this.category
+      }).groups
+    },
+    filterTeams() {
+      return this.prefectures.find(prefecture => {
+        return prefecture.id === this.prefecture
+      }).teams
+    }
+  },
+  watch: {
+    dialog(value) {
+      if (value) {
+        this.getLeagueData()
+        this.getPrefectureTeamData()
+      }
+    }
+  },
+  methods: {
+    open() {
+      this.registerPlayer = true
+      this.dialog = true
+    },
+    close() {
+      this.$refs.observer.reset()
+      this.$refs.form.reset()
+      this.dialog = false
+    },
+    changeForm() {
+      this.registerPlayer = !this.registerPlayer
+      this.registerTeam = !this.registerTeam
+    },
+    async getLeagueData() {
+      const response = await this.$axios.get("/api/v1/leagues")
+      this.leagues = response.data
+    },
+    async getPrefectureTeamData() {
+      const response = await this.$axios.get("/api/v1/prefecture_teams")
+      this.prefectures = response.data
+    },
+    async sendPlayerData() {
+      try {
+        const response = await this.$axios.post("/api/v1/profile", {
+          profile: this.profile
+        })
+        this.close()
+      } catch(err) {
+        this.$refs.observer.setErrors(err.response.data.errors)
+      }
+    },
+    pushTeam(team) {
+      this.prefectures.find(prefecture => {
+        return prefecture.id === team.prefectureId
+      }).teams.push(team)
+      this.changeForm()
+    },
+    setGroupId() {
+      if (this.filterGroups.length === 1) {
+        this.profile.groupId = this.filterGroups[0].id
+      }
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/ThePlayerDialogTeam.vue
+++ b/app/javascript/components/parts/ThePlayerDialogTeam.vue
@@ -1,0 +1,171 @@
+<template>
+  <v-card>
+    <v-btn
+      icon
+      @click="$emit('click-back')"
+    >
+      <v-icon>
+        mdi-arrow-left
+      </v-icon>
+    </v-btn>
+    <v-card-title
+      class="pt-0 font-weight-bold justify-center text-h5"
+    >
+      チーム登録
+    </v-card-title>
+    <v-divider />
+    <v-card-text>
+      <ValidationObserver
+        ref="observer"
+        v-slot="{ handleSubmit }"
+      >
+        <v-form ref="form">
+          <v-container>
+            <v-row>
+              <v-col
+                class="mt-3"
+                cols="12"
+              >
+                <span
+                  class="font-weight-bold black--text"
+                  :style="$vuetify.breakpoint.mobile ? 'font-size: 10px;' : 'font-size: 12px'"
+                >
+                  ＊大会に記載しているチーム名で登録してください。
+                  <br>
+                  ＊〇〇高校、〇〇U-18、〇〇ユースの形で登録してください。
+                  <br>
+                  ＊2nd、3rdなどの区別はしないでください。
+                </span>
+              </v-col>
+              <v-col cols="12">
+                <ValidationProvider
+                  v-slot="{ errors }"
+                  rules="required"
+                  name="都道府県"
+                  vid="prefecture"
+                >
+                  <v-select
+                    v-model="team.prefectureId"
+                    outlined
+                    dense
+                    label="都道府県"
+                    required
+                    :items="prefectures"
+                    item-value="id"
+                    item-text="name"
+                    background-color="#F2F4F8"
+                    :error-messages="errors"
+                  />
+                </ValidationProvider>
+              </v-col>
+              <v-col
+                cols="12"
+                class="pt-0"
+              >
+                <ValidationProvider
+                  v-slot="{ errors }"
+                  rules="required"
+                  vid="name"
+                  name="チーム"
+                >
+                  <v-text-field
+                    v-model="team.name"
+                    outlined
+                    dense
+                    required
+                    label="チーム"
+                    background-color="#F2F4F8"
+                    :error-messages="errors"
+                  />
+                </ValidationProvider>
+              </v-col>
+              <v-col
+                cols="12"
+                class="pt-0"
+              >
+                <ValidationProvider
+                  v-slot="{ errors }"
+                  rules="required"
+                  name="選択"
+                  vid="kind"
+                >
+                  <v-select
+                    v-model="team.kind"
+                    outlined
+                    dense
+                    label="選択"
+                    :items="kinds"
+                    item-value="id"
+                    item-text="name"
+                    required
+                    background-color="#F2F4F8"
+                    :error-messages="errors"
+                  />
+                </ValidationProvider>
+              </v-col>
+              <v-col
+                cols="12"
+                class="pt-0"
+              >
+                <v-btn
+                  color="#3949AB"
+                  class="font-weight-bold"
+                  large
+                  dark
+                  block
+                  depressed
+                  @click="handleSubmit(sendTeamData)"
+                >
+                  登録する
+                </v-btn>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-form>
+      </ValidationObserver>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: {
+    prefectures: {
+      type: Array,
+      default: () => {},
+      required: true
+    }
+  },
+  data() {
+    return {
+      team: {
+        prefectureId: "",
+        name: "",
+        kind: "",
+      },
+      kinds: [
+        {
+          id: 0,
+          name: "高体連"
+        },
+        {
+          id: 1,
+          name: "ユースチーム"
+        }
+      ]
+    }
+  },
+  methods: {
+    async sendTeamData() {
+      try {
+        const response = await this.$axios.post("/api/v1/teams", {
+          team: this.team
+        })
+        this.$emit("create-team", response.data)
+      } catch(err) {
+        this.$refs.observer.setErrors(err.response.data.errors)
+      }
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## やったこと
選手編集ダイアログの作成

## やらないこと
mobileでのダイアログ起動ボタンの作成
選手情報を表示するビューの作成
選手情報のアップデート関連

## できるようになること（ユーザ目線）
選手情報を作成できるようになる
チームを作成できるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
想定通りに表示されることを確認
想定通りにリクエストを飛ばすことを確認
選手の情報を編集できることを確認

## その他
特になし
