### PR TITLE
モバイル用の選手情報エリアを作成 #5

### DIFF
--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -41,8 +41,10 @@
     <v-divider />
     <div class="profile-contents mt-4">
       <information
-        v-if="userInformation"
+        v-if="userInformation && loading"
         :user="currentUser"
+        :profile="profile"
+        @click-player="openPlayerDialog"
       />
       <review-list
         v-if="reviewList"

--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -9,7 +9,7 @@
       :user="currentUser"
       :user-edit="userEdit"
       :profile="profile"
-      @click-player="$refs.playerDialog.open()"
+      @click-player="openPlayerDialog"
       @click-edit="openEditDialog"
       @click-introduction="userEdit = { ...currentUser }"
       @click-update="updateIntroduction"
@@ -125,6 +125,9 @@ export default {
     openEditDialog() {
       this.setUserEdit()
       this.$refs.profileEditDialog.open()
+    },
+    openPlayerDialog() {
+      this.$refs.playerDialog.open()
     },
     async getProfileData() {
       const response = await this.$axios.get("/api/v1/profile")

--- a/app/javascript/components/parts/Information.vue
+++ b/app/javascript/components/parts/Information.vue
@@ -1,6 +1,11 @@
 <template>
   <v-container>
     <v-row>
+      <information-player
+        v-if="$vuetify.breakpoint.mobile"
+        :profile="profile"
+        @click-player="$emit('click-player')"
+      />
       <!-- 経歴 -->
       <information-career />
       <!-- つながり -->
@@ -12,19 +17,26 @@
 </template>
 
 <script>
+import InformationPlayer from "./informationPlayer"
 import InformationCareer from "./InformationCareer"
 import InformationRelation from "./InformationRelation"
 
 export default {
   components: {
-     InformationCareer,
-     InformationRelation
+    InformationPlayer,
+    InformationCareer,
+    InformationRelation
   },
   props: {
     user: {
       type: Object,
       default: () => {},
       required: true
+    },
+    profile: {
+      type: Object,
+      default: () => {},
+      required: false
     }
   }
 }

--- a/app/javascript/components/parts/Information.vue
+++ b/app/javascript/components/parts/Information.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import InformationPlayer from "./informationPlayer"
+import InformationPlayer from "./InformationPlayer"
 import InformationCareer from "./InformationCareer"
 import InformationRelation from "./InformationRelation"
 

--- a/app/javascript/components/parts/InformationPlayer.vue
+++ b/app/javascript/components/parts/InformationPlayer.vue
@@ -1,0 +1,82 @@
+<template>
+  <v-col cols="12">
+    <v-card
+      elevation="1"
+      outlined
+      justify-space-between
+    >
+      <v-card-title v-if="!profile" class="font-weight-bold">
+        選手
+        <v-spacer />
+        <v-btn color="primary" text @click="$emit('click-player')">
+          選手情報を追加
+        </v-btn>
+      </v-card-title>
+      <div v-else v-for="data in profileData" :key="data.id">
+        <v-card-title class="font-weight-bold">
+          {{ data.name }}
+          <v-spacer />
+          <v-btn icon>
+            <v-icon>
+              mdi-pencil
+            </v-icon>
+          </v-btn>
+        </v-card-title>
+        <v-card-text align="center" class="font-weight-bold" style="color: rgba(0,0,0,.6);" >
+          {{ data.information }}
+        </v-card-text>
+      </div>
+    </v-card>
+  </v-col>
+</template>
+
+<script>
+export default {
+  props: {
+    profile: {
+      type: Object,
+      default: () => {},
+      required: false
+    }
+  },
+  computed: {
+    profileData() {
+      return [
+        {
+          name: "チーム",
+          information: this.teamName
+        },
+        {
+          name: "リーグ",
+          information: this.leagueName
+        },
+        {
+          name: "ポジション",
+          information: this.profile.position
+        },
+        {
+          name: "背番号",
+          information: this.uniformNumber
+        },
+      ]
+    },
+    teamName() {
+      return `${this.profile.team.name}(${this.profile.team.prefecture.name})`
+    },
+    leagueName() {
+      if (this.profile.group.name) {
+        return `${this.profile.group.category.league.name}${this.profile.group.category.name}${this.profile.group.name}`
+      } else {
+        return `${this.profile.group.category.league.name}${this.profile.group.category.name}`
+      }
+    },
+    uniformNumber() {
+      if (this.profile.practiceNumber) {
+        return `公式戦${this.profile.officialNumber} 練習${this.profile.practiceNumber}`
+      } else {
+        return this.profile.officialNumber
+      }
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/ThePlayerDialog.vue
+++ b/app/javascript/components/parts/ThePlayerDialog.vue
@@ -42,7 +42,8 @@
                   </span>
                   <br>
                   <span
-                    class="font-weight-bold text-caption"
+                    class="font-weight-bold"
+                    :style="$vuetify.breakpoint.mobile ? 'font-size: 10px;' : 'font-size: 12px;'"
                   >
                     *所属チームが見つからない場合は
                     <span


### PR DESCRIPTION
## やったこと
モバイル用の選手情報エリアを作成

## やらないこと
選手情報更新に関係すること

## できるようになること（ユーザ目線）
スマホで選手情報を閲覧、作成できる

## できなくなること（ユーザ目線）
特になし

## 動作確認
モバイルで想定通りに表示、作成できることを確認

## その他
特になし
