### PR TITLE
修正 #5

### DIFF
--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -85,7 +85,7 @@
     />
     <the-player-dialog
       ref="playerDialog"
-      @click-register="sendPlayerData"
+      @click-register="createPlayerData"
     />
   </div>
 </template>
@@ -179,14 +179,15 @@ export default {
         this.$refs.profileEditDialog.sendActivationEmail()
       }
     },
-    async sendPlayerData(profile) {
+    async createPlayerData(profile) {
       try {
         const response = await this.$axios.post("/api/v1/profile", {
           profile: profile
         })
         this.profile = response.data
+        this.$refs.playerDialog.close()
       } catch(err) {
-        this.$refs.observer.setErrors(err.response.data.errors)
+        this.$refs.playerDialog.setErrors(err.response.data.errors)
       }
     },
   }

--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -173,7 +173,7 @@ export default {
     async updateProfile() {
       const response = await this.$store.dispatch("user/updateCurrentUser", this.userEdit)
       if (response.errors) return this.$refs.profileEditDialog.setErrors(response.errors)
-      if (response.activation) {
+      if (response.activationState === "active") {
         this.$refs.profileEditDialog.close()
       } else {
         this.$refs.profileEditDialog.sendActivationEmail()

--- a/app/javascript/components/parts/SendActivationEmail.vue
+++ b/app/javascript/components/parts/SendActivationEmail.vue
@@ -58,7 +58,34 @@
           </v-col>
         </v-row>
       </v-container>
-      <slot name="resend" />
+      <v-container>
+        <v-divider
+          class="mt-n3"
+        />
+        <v-row>
+          <v-col
+            cols="12"
+            class="mt-6 pb-0"
+            align="center"
+          >
+            <p
+              class="font-weight-bold black--text"
+            >
+              メールが届かない方はこちら
+            </p>
+          </v-col>
+          <v-col class="pt-0">
+            <v-btn
+              block
+              depressed
+              outlined
+              @click="resendEmail"
+            >
+              再度送信
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-container>
     </v-card-text>
   </v-card>
 </template>
@@ -69,6 +96,13 @@ export default {
     email: {
       type: String,
       required: true
+    }
+  },
+  methods: {
+    async resendEmail() {
+      await this.$axios.post("/api/v1/account_activations", {
+        email: this.email
+      })
     }
   }
 }

--- a/app/javascript/components/parts/SendActivationEmail.vue
+++ b/app/javascript/components/parts/SendActivationEmail.vue
@@ -25,7 +25,7 @@
             <p
               class="font-weight-bold black--text"
             >
-              ご登録のアドレスにアカウント認証メールを送信しました
+              ご登録のアドレスにアカウント<br v-if="$vuetify.breakpoint.mobile">認証メールを送信しました
             </p>
           </v-col>
           <v-col

--- a/app/javascript/components/parts/SignupDialog.vue
+++ b/app/javascript/components/parts/SignupDialog.vue
@@ -21,34 +21,7 @@
         @click-close="Object.assign($data, $options.data())"
       >
         <template #resend>
-          <v-container>
-            <v-divider
-              class="mt-n3"
-            />
-            <v-row>
-              <v-col
-                cols="12"
-                class="mt-6 pb-0"
-                align="center"
-              >
-                <p
-                  class="font-weight-bold black--text"
-                >
-                  メールが届かない方はこちら
-                </p>
-              </v-col>
-              <v-col class="pt-0">
-                <v-btn
-                  block
-                  depressed
-                  outlined
-                  @click="resendEmail"
-                >
-                  再度送信
-                </v-btn>
-              </v-col>
-            </v-row>
-          </v-container>
+
         </template>
       </send-activation-email>
     </v-dialog>
@@ -93,11 +66,6 @@ export default {
       this.sendEmail = true
       this.email = email
     },
-    async resendEmail() {
-      await this.$axios.post("/api/v1/account_activations", {
-        email: this.email
-      })
-    }
   }
 }
 </script>

--- a/app/javascript/components/parts/SignupDialog.vue
+++ b/app/javascript/components/parts/SignupDialog.vue
@@ -1,31 +1,25 @@
 <template>
-  <div class="text-center">
-    <v-dialog
-      v-model="dialog"
-      width="500"
-      :persistent="true"
-    >
-      <signup-dialog-select
-        v-if="registerSelect"
-        @email-register="showForm"
-        @click-close="dialog = false"
-      />
-      <signup-dialog-form
-        v-if="emailRegister"
-        @create-user="showSendEmail"
-        @click-back="closeForm"
-      />
-      <send-activation-email
-        v-if="sendEmail"
-        :email="email"
-        @click-close="Object.assign($data, $options.data())"
-      >
-        <template #resend>
-
-        </template>
-      </send-activation-email>
-    </v-dialog>
-  </div>
+  <v-dialog
+    v-model="dialog"
+    width="500"
+    :persistent="true"
+  >
+    <signup-dialog-select
+      v-if="registerSelect"
+      @email-register="showForm"
+      @click-close="dialog = false"
+    />
+    <signup-dialog-form
+      v-if="emailRegister"
+      @create-user="showSendEmail"
+      @click-back="closeForm"
+    />
+    <send-activation-email
+      v-if="sendEmail"
+      :email="email"
+      @click-close="Object.assign($data, $options.data())"
+    />
+  </v-dialog>
 </template>
 
 <script>

--- a/app/javascript/components/parts/ThePlayerDialog.vue
+++ b/app/javascript/components/parts/ThePlayerDialog.vue
@@ -376,7 +376,9 @@ export default {
     },
     clickRegister() {
       this.$emit("click-register", this.profile)
-      this.close()
+    },
+    setErrors(errors) {
+      this.$refs.observer.setErrors(errors)
     },
     async getLeagueData() {
       const response = await this.$axios.get("/api/v1/leagues")

--- a/app/javascript/components/parts/TheProfileEditDialog.vue
+++ b/app/javascript/components/parts/TheProfileEditDialog.vue
@@ -5,7 +5,9 @@
     :persistent="true"
     scrollable
   >
-    <v-card>
+    <v-card
+       v-if="form"
+    >
       <v-btn
         icon
         @click="close"
@@ -21,7 +23,6 @@
       </v-card-title>
       <v-divider />
       <v-card-text
-        v-if="form"
         :style="{ 'height: 450px': $vuetify.breakpoint.mobile }"
         :class="{ 'px-2': $vuetify.breakpoint.mobile }"
       >
@@ -184,6 +185,7 @@
     <send-activation-email
       v-if="sendEmail"
       :email="email"
+      @click-close="close"
     />
   </v-dialog>
 </template>

--- a/app/javascript/components/parts/TheResendActivationEmailDialog.vue
+++ b/app/javascript/components/parts/TheResendActivationEmailDialog.vue
@@ -4,7 +4,9 @@
     width="500"
     :persistent="true"
   >
-    <v-card>
+    <v-card
+      v-if="form"
+    >
       <v-btn
         icon
         @click="closeDialog"
@@ -20,7 +22,6 @@
       </v-card-title>
       <v-divider />
       <v-card-text
-        v-if="form"
         class="pt-6 pb-0"
       >
         <ValidationObserver
@@ -72,11 +73,12 @@
           </v-form>
         </ValidationObserver>
       </v-card-text>
-      <send-activation-email
-        v-if="sendEmail"
-        :email="email"
-      />
     </v-card>
+    <send-activation-email
+      v-if="sendEmail"
+      :email="email"
+      @click-close="closeDialog"
+    />
   </v-dialog>
 </template>
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,12 +1,8 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :first_name, :last_name, :avatar, :birth_date, :role, :introduction,
-             :email, :activation
+             :email, :activation_state
 
   def role
     object.role_i18n
-  end
-
-  def activation
-    object.activation_state == 'active'
   end
 end


### PR DESCRIPTION
## やったこと
user_serializerのレスポンスを修正
選手情報登録でエラーメッセージが表示できるように修正
認証メール送信で再度送信部分も表示させるように
UIが崩れていたのを修正

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
特になし

## 動作確認
修正したことで想定通りに表示、処理されることを確認

## その他
特になし
