### PR TITLE
選手情報変更でもチームを登録できるように #5

### DIFF
--- a/app/javascript/components/parts/PlayerCardEdit.vue
+++ b/app/javascript/components/parts/PlayerCardEdit.vue
@@ -105,12 +105,6 @@ export default {
         break
       }
     },
-    clickCancel() {
-      this.$emit("click-cancel")
-    },
-    clickUpdate() {
-      this.$emit("click-update")
-    },
     setErrors(errors) {
       this.$refs.observer.setErrors(errors)
     }

--- a/app/javascript/components/parts/PlayerCardEdit.vue
+++ b/app/javascript/components/parts/PlayerCardEdit.vue
@@ -1,7 +1,7 @@
 <template>
   <ValidationObserver
     ref="observer"
-    v-slot="{ handleSubmit }"
+    v-slot="{ invalid }"
   >
     <v-card-text class="pb-0">
       <v-container>
@@ -33,14 +33,15 @@
       <v-btn
         color="primary"
         text
-        @click="clickCancel"
+        @click="$emit('click-cancel')"
       >
         キャンセル
       </v-btn>
       <v-btn
         color="primary"
         text
-        @click="handleSubmit(clickUpdate)"
+        :disabled="invalid"
+        @click="$emit('click-update')"
       >
         更新
       </v-btn>

--- a/app/javascript/components/parts/PlayerFormTeam.vue
+++ b/app/javascript/components/parts/PlayerFormTeam.vue
@@ -55,11 +55,21 @@
         @change="$emit('update:teamId', $event)"
       />
     </ValidationProvider>
+    <team-register-dialog
+      ref="teamRegisterDialog"
+      :prefectures="prefectures"
+      @create-team="pushTeam"
+    />
   </v-col>
 </template>
 
 <script>
+import TeamRegisterDialog from "./TeamRegisterDialog"
+
 export default {
+  components: {
+    TeamRegisterDialog
+  },
   props: {
     prefecture: {
       type: Number,

--- a/app/javascript/components/parts/PlayerFormTeam.vue
+++ b/app/javascript/components/parts/PlayerFormTeam.vue
@@ -100,6 +100,11 @@ export default {
     this.getPrefectureTeamData()
   },
   methods: {
+    pushTeam(team) {
+      this.prefectures.find(prefecture => {
+        return prefecture.id === team.prefectureId
+      }).teams.push(team)
+    },
     async getPrefectureTeamData() {
       const response = await this.$axios.get("/api/v1/prefecture_teams")
       this.loading = true

--- a/app/javascript/components/parts/PlayerFormTeam.vue
+++ b/app/javascript/components/parts/PlayerFormTeam.vue
@@ -6,7 +6,19 @@
       所属チーム編集
     </span>
     <br>
-    <span class="text-caption">チームを登録される方は <strong class="red--text">こちら</strong> をクリック</span>
+    <span
+      class="text-caption"
+    >
+      チームを登録される方は
+      <strong
+        class="red--text"
+        style="cursor: pointer;"
+        @click="$refs.teamRegisterDialog.open()"
+      >
+        こちら
+      </strong>
+      をクリック
+    </span>
     <v-select
       v-if="loading"
       v-model="prefectureId"

--- a/app/javascript/components/parts/PlayerTableEdit.vue
+++ b/app/javascript/components/parts/PlayerTableEdit.vue
@@ -105,12 +105,6 @@ export default {
         break
       }
     },
-    clickCancel() {
-      this.$emit("click-cancel")
-    },
-    clickUpdate() {
-      this.$emit("click-update")
-    },
     setErrors(errors) {
       this.$refs.observer.setErrors(errors)
     }

--- a/app/javascript/components/parts/PlayerTableEdit.vue
+++ b/app/javascript/components/parts/PlayerTableEdit.vue
@@ -9,7 +9,7 @@
           <player-form-team
             v-if="teamEdit"
             :prefecture="prefecture"
-            v-bind.sync="profileEdit"
+            :team-id.sync="profileEdit.teamId"
           />
           <player-form-league
             v-if="leagueEdit"

--- a/app/javascript/components/parts/PlayerTableEdit.vue
+++ b/app/javascript/components/parts/PlayerTableEdit.vue
@@ -1,7 +1,7 @@
 <template>
   <ValidationObserver
     ref="observer"
-    v-slot="{ handleSubmit }"
+    v-slot="{ invalid }"
   >
     <v-card-text class="pb-0">
       <v-container>
@@ -40,7 +40,8 @@
       <v-btn
         color="primary"
         text
-        @click="handleSubmit(clickUpdate)"
+        :disabled="invalid"
+        @click="$emit('click-update')"
       >
         更新
       </v-btn>

--- a/app/javascript/components/parts/PlayerTableEdit.vue
+++ b/app/javascript/components/parts/PlayerTableEdit.vue
@@ -33,7 +33,7 @@
       <v-btn
         color="primary"
         text
-        @click="clickCancel"
+        @click="$emit('click-cancel')"
       >
         キャンセル
       </v-btn>


### PR DESCRIPTION
## やったこと
選手情報変更ではhandleSubmitからinvalidに変更
それに伴い不要なコードを削除
選手情報変更でもチームを登録できるように実装(チーム編集フォームから)

## やらないこと
特になし

## できるようになること（ユーザ目線）
選手情報変更でもチームを登録できるようになる　

## できなくなること（ユーザ目線）
特になし

## 動作確認
エラーイベントがinvalidになっていることを確認
チーム登録ができることを確認

## その他
特になし
