### PR TITLE
修正 #5

### DIFF
--- a/app/javascript/components/parts/PlayerFormLeague.vue
+++ b/app/javascript/components/parts/PlayerFormLeague.vue
@@ -76,18 +76,18 @@ export default {
       required: true
     },
     league: {
-      type: Number,
-      default: 0,
+      type: [Number, String],
+      default: "",
       required: true
     },
     category: {
       type: [Number, String],
-      default: 0,
+      default: "",
       required: true
     },
     groupId: {
       type: [Number, String],
-      default: 0,
+      default: "",
       required: true
     }
   },

--- a/app/javascript/components/parts/PlayerFormLeague.vue
+++ b/app/javascript/components/parts/PlayerFormLeague.vue
@@ -8,12 +8,9 @@
     >
       <v-select
         v-model="leagueId"
-        class="mt-4"
         outlined
         dense
-        :loading="!loading"
         label="リーグ"
-        :disabled="!loading"
         :items="leagues"
         item-value="id"
         item-text="name"
@@ -31,7 +28,6 @@
     >
       <v-select
         v-model="categoryId"
-        :disabled="!loading"
         class="mt-1"
         outlined
         dense
@@ -54,7 +50,6 @@
       vid="group"
     >
       <v-select
-        :disabled="!loading"
         :value="groupId"
         class="mt-1"
         outlined
@@ -93,10 +88,8 @@ export default {
   },
   data() {
     return {
-      loading: false,
       leagueId: this.league,
       categoryId: this.category,
-      leagues: []
     }
   },
   computed: {

--- a/app/javascript/components/parts/PlayerFormLeague.vue
+++ b/app/javascript/components/parts/PlayerFormLeague.vue
@@ -70,6 +70,11 @@
 <script>
 export default {
   props: {
+    leagues: {
+      type: Array,
+      default: () => {},
+      required: true
+    },
     league: {
       type: Number,
       default: 0,

--- a/app/javascript/components/parts/PlayerFormLeague.vue
+++ b/app/javascript/components/parts/PlayerFormLeague.vue
@@ -4,6 +4,7 @@
       v-slot="{ errors }"
       rules="required"
       name="リーグ"
+      vid="group"
     >
       <v-select
         v-model="leagueId"

--- a/app/javascript/components/parts/PlayerFormLeague.vue
+++ b/app/javascript/components/parts/PlayerFormLeague.vue
@@ -109,9 +109,6 @@ export default {
       }).groups
     }
   },
-  created() {
-    this.getLeagueData()
-  },
   methods: {
     setGroupId() {
       if (this.filterGroups.length === 1) {

--- a/app/javascript/components/parts/PlayerFormLeague.vue
+++ b/app/javascript/components/parts/PlayerFormLeague.vue
@@ -16,7 +16,7 @@
         item-text="name"
         background-color="#F2F4F8"
         :error-messages="errors"
-        @click="categoryId = ''"
+        @click="resetId"
       />
     </ValidationProvider>
     <ValidationProvider
@@ -113,10 +113,10 @@ export default {
         this.$emit("update:groupId", this.filterGroups[0].id)
       }
     },
-    async getLeagueData() {
-      const response = await this.$axios.get("/api/v1/leagues")
-      this.leagues = response.data
-      this.loading = true
+    resetId() {
+      this.$emit("update:groupId", "")
+      this.categoryId = ""
+      this.leagueId = ""
     }
   }
 }

--- a/app/javascript/components/parts/PlayerFormLeague.vue
+++ b/app/javascript/components/parts/PlayerFormLeague.vue
@@ -1,10 +1,5 @@
 <template>
-  <v-col cols="12">
-    <span
-      class="font-weight-bold text-h6 black--text"
-    >
-      所属リーグ編集
-    </span>
+  <div>
     <ValidationProvider
       v-slot="{ errors }"
       rules="required"
@@ -73,7 +68,7 @@
         @change="$emit('update:groupId', $event)"
       />
     </ValidationProvider>
-  </v-col>
+  </div>
 </template>
 
 <script>

--- a/app/javascript/components/parts/PlayerFormLeague.vue
+++ b/app/javascript/components/parts/PlayerFormLeague.vue
@@ -20,7 +20,7 @@
       />
     </ValidationProvider>
     <ValidationProvider
-      v-if="loading && leagueId"
+      v-if="leagueId"
       v-slot="{ errors }"
       rules="required"
       name="カテゴリ"
@@ -43,7 +43,7 @@
       />
     </ValidationProvider>
     <ValidationProvider
-      v-if="loading && categoryId && filterGroups.length !== 1"
+      v-if="categoryId && filterGroups.length !== 1"
       v-slot="{ errors }"
       rules="required"
       name="グループ"


### PR DESCRIPTION
## やったこと
タイトルをコンポーネントから削除
プロップスのデフォルトを空白に修正
リーグにvidを追加
リーグクリック時に全てのIDをリセットするメソッドを作成
リーグのデータは親のコンポーネントで取得するため削除

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
特になし

## 動作確認
リーグにvidを追加したことでエラーメッセージが表示されることを確認
リーグクリック時にリセットされるのでフロント側でエラーを検知することができることを確認

## その他
特になし
