### PR TITLE
シリアライザーの修正 #4

### DIFF
--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,3 +1,3 @@
 class CategorySerializer < ActiveModel::Serializer
-  attributes :id, :name, :league_id
+  attributes :id, :name
 end

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -1,3 +1,3 @@
 class GroupSerializer < ActiveModel::Serializer
-  attributes :id, :name, :category_id
+  attributes :id, :name
 end

--- a/app/serializers/team_serializer.rb
+++ b/app/serializers/team_serializer.rb
@@ -1,7 +1,3 @@
 class TeamSerializer < ActiveModel::Serializer
-  attributes :id, :name, :kind, :prefecture_id
-
-  def kind
-    object.kind_i18n
-  end
+  attributes :id, :name, :prefecture_id
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,8 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :first_name, :last_name, :avatar, :birth_date, :role, :introduction,
              :email, :activation_state
-
-  def role
-    object.role_i18n
-  end
 end


### PR DESCRIPTION
## やったこと
シリアライザーの修正
CategorySerializerから:league_idを削除
GroupSerializerから:category_idを削除
TeamSerializerから:kindを削除
enumは日本語化しないでそのままに

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
特になし

## 動作確認
不要なカラムがレスポンスに含まれていないことを確認
enumが日本語化していないことを確認

## その他
特になし
