### PR TITLE
アカウントタブを追加 #186

### DIFF
--- a/app/javascript/components/globals/TheHeader.vue
+++ b/app/javascript/components/globals/TheHeader.vue
@@ -97,7 +97,7 @@
                 block
                 large
                 class="justify-start"
-                @click="pushPage('/settings/profile', 'mySetting', 'profile')"
+                @click="pushPage('/settings/account', 'mySetting', 'account')"
               >
                 <v-icon
                   class="mr-2"

--- a/app/javascript/components/pages/MySetting.vue
+++ b/app/javascript/components/pages/MySetting.vue
@@ -22,6 +22,13 @@
         <v-divider />
       </v-col>
       <!-- プロフィール -->
+      <v-col class="pt-0">
+        <setting-account
+          v-if="$route.path === '/settings/account'"
+          :user="currentUser"
+          @update-user="fetchCurrentUser"
+        />
+      </v-col>
       <setting-profile
         v-if="$route.path === '/settings/profile'"
         ref="profileEdit"
@@ -54,6 +61,7 @@
 <script>
 import { mapGetters } from 'vuex'
 import SettingsTab from "../parts/SettingsTab"
+import SettingAccount from "../parts/SettingAccount"
 import SettingProfile from "../parts/SettingProfile"
 import SettingPlayer from "../parts/SettingPlayer"
 import TheBreadCrumb from "../globals/TheBreadCrumb"
@@ -62,10 +70,11 @@ import SendActivationEmail from "../parts/SendActivationEmail"
 export default {
   components: {
     SettingsTab,
+    SettingAccount,
     SettingProfile,
     SettingPlayer,
     TheBreadCrumb,
-    SendActivationEmail
+    SendActivationEmail,
   },
   data() {
     return {

--- a/app/javascript/components/parts/SettingAccount.vue
+++ b/app/javascript/components/parts/SettingAccount.vue
@@ -1,0 +1,109 @@
+<template>
+  <div>
+    <v-list color="#FAFAFA">
+      <v-list-item class="px-0">
+        <v-list-item-content>
+          <v-list-item-title class="font-weight-bold">
+            パスワード変更
+          </v-list-item-title>
+          <v-list-item-subtitle :class="$vuetify.breakpoint.mobile ? 'mt-1 text-wrap text-caption' : 'mt-1'">
+            新しいパスワードに変更できます
+          </v-list-item-subtitle>
+          <v-btn
+            v-if="$vuetify.breakpoint.mobile"
+            max-width="90"
+            class="font-weight-bold text-caption mt-1"
+          >
+            変更する
+          </v-btn>
+        </v-list-item-content>
+        <v-btn
+          v-if="!$vuetify.breakpoint.mobile"
+          class="font-weight-bold"
+        >
+          変更する
+        </v-btn>
+      </v-list-item>
+      <v-divider
+        class="mt-3"
+      />
+      <v-list-item class="px-0 mt-3">
+        <v-list-item-content>
+          <v-list-item-title class="font-weight-bold">
+            選手登録解除
+          </v-list-item-title>
+          <v-list-item-subtitle :class="$vuetify.breakpoint.mobile ? 'mt-1 text-wrap text-caption' : 'mt-1'">
+            選手登録が解除され評価を受けることができなくなります
+          </v-list-item-subtitle>
+          <v-btn
+            v-if="$vuetify.breakpoint.mobile"
+            max-width="90"
+            class="font-weight-bold text-caption mt-1"
+            :disabled="user.role !== 'player'"
+            @click="$refs.playerReleaseDialog.open()"
+          >
+            解除する
+          </v-btn>
+        </v-list-item-content>
+        <v-btn
+          v-if="!$vuetify.breakpoint.mobile"
+          class="font-weight-bold"
+          :disabled="user.role !== 'player'"
+          @click="$refs.playerReleaseDialog.open()"
+        >
+          解除する
+        </v-btn>
+      </v-list-item>
+      <v-divider
+        class="mt-3"
+      />
+      <v-list-item class="px-0 mt-3">
+        <v-list-item-content>
+          <v-list-item-title class="font-weight-bold">
+            退会
+          </v-list-item-title>
+          <v-list-item-subtitle :class="$vuetify.breakpoint.mobile ? 'mt-1 text-wrap text-caption' : 'mt-1'">
+            Famoのサービスを利用できなくなります
+          </v-list-item-subtitle>
+          <v-btn
+            v-if="$vuetify.breakpoint.mobile"
+            max-width="90"
+            class="font-weight-bold text-caption mt-1"
+          >
+            退会する
+          </v-btn>
+        </v-list-item-content>
+        <v-btn
+          v-if="!$vuetify.breakpoint.mobile"
+          class="font-weight-bold"
+        >
+          退会する
+        </v-btn>
+      </v-list-item>
+      <v-divider
+        class="mt-3"
+      />
+    </v-list>
+    <the-player-release-dialog
+      ref="playerReleaseDialog"
+      @update-user="$emit('update-user')"
+    />
+  </div>
+</template>
+
+<script>
+import ThePlayerReleaseDialog from "../parts/ThePlayerReleaseDialog"
+
+export default {
+  components: {
+    ThePlayerReleaseDialog
+  },
+  props: {
+    user: {
+      type: Object,
+      default: () => {},
+      required: true
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/SettingsTab.vue
+++ b/app/javascript/components/parts/SettingsTab.vue
@@ -20,6 +20,10 @@ export default {
     return {
       settings: [
         {
+          name: "アカウント",
+          params: "account"
+        },
+        {
           name: "プロフィール",
           params: "profile"
         },


### PR DESCRIPTION
## やったこと
アカウントタブを追加
タブ内にはパスワード変更、選手登録解除、退会を作成
アカウント設定クリックのデフォルトをアカウントタブに変更

## やらないこと
それぞれの処理

## できるようになること（ユーザ目線）
アカウントタブが表示されるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
アカウントタブが表示されることを確認
アカウント設定クリックでアカウントタブに遷移することを確認

## その他

