### PR TITLE
カラムの型を変更 #200

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -5,7 +5,7 @@ class Profile < ApplicationRecord
 
   validates :position, presence: true
   validates :official_number, presence: true, numericality: true
-  validates :practice_number, numericality: true, allow_nil: true
+  validates :practice_number, numericality: true, allow_blank: true
   validates :career, length: { maximum: 50 }
 
   enum position: { GK: 0, DF: 1, MF: 2, FW: 3 }

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -63,6 +63,7 @@ ja:
       taken: この%{attribute}は既に存在します
       too_long: "%{attribute}は%{count}文字以内で入力してください"
       too_short: "%{attribute}は%{count}文字以上で入力してください"
+      not_a_number: "%{attribute}は数字で入力してください"
   enums:
     user:
       role:

--- a/db/migrate/20210708115233_change_datatype_official_number_and_practice_number_of_profiles.rb
+++ b/db/migrate/20210708115233_change_datatype_official_number_and_practice_number_of_profiles.rb
@@ -1,0 +1,6 @@
+class ChangeDatatypeOfficialNumberAndPracticeNumberOfProfiles < ActiveRecord::Migration[6.1]
+  def change
+    change_column :profiles, :official_number, :string
+    change_column :profiles, :practice_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_08_103930) do
+ActiveRecord::Schema.define(version: 2021_07_08_115233) do
 
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -42,8 +42,8 @@ ActiveRecord::Schema.define(version: 2021_07_08_103930) do
 
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "position", default: 0, null: false
-    t.integer "official_number", null: false
-    t.integer "practice_number"
+    t.string "official_number", null: false
+    t.string "practice_number"
     t.string "career"
     t.bigint "user_id", null: false
     t.bigint "group_id", null: false


### PR DESCRIPTION
## やったこと
背番号のカラムの型を変更
01などが入らない保証がないためstringに変更　

## やらないこと
特になし

## できるようになること（ユーザ目線）
01などの背番号も登録できるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
01なども登録できるようになることを確認

## その他
特になし
