### PR TITLE
バリデーションの追加 #200

### DIFF
--- a/app/javascript/components/parts/TheTeamRegisterDialog.vue
+++ b/app/javascript/components/parts/TheTeamRegisterDialog.vue
@@ -76,7 +76,7 @@
                 >
                   <ValidationProvider
                     v-slot="{ errors }"
-                    rules="required"
+                    rules="required|max:50"
                     vid="name"
                     name="チーム"
                   >

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,7 +2,7 @@ class Team < ApplicationRecord
   belongs_to :prefecture
   has_many :profiles, dependent: :restrict_with_exception
 
-  validates :name, presence: true, uniqueness: { scope: :prefecture }
+  validates :name, presence: true, length: { maximum: 50 }, uniqueness: { scope: :prefecture }
   validates :kind, presence: true
 
   enum kind: { high_school: 0, youth: 1 }


### PR DESCRIPTION
## やったこと
チームの名前にバリデーションを追加
50文字以内とする

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
５０文字以上のチーム名を登録できなくなる

## 動作確認
想定通りに表示されることを確認

## その他
特になし
