### PR TITLE
修正 #200

### DIFF
--- a/app/controllers/api/v1/account_activations_controller.rb
+++ b/app/controllers/api/v1/account_activations_controller.rb
@@ -2,7 +2,6 @@ class Api::V1::AccountActivationsController < ApplicationController
   def create
     if (user = User.find_by(email: params[:email]))
       if !user.activation_token.nil?
-        user.setup_activation_attributes
         if user.save
           UserMailer.activation_needed_email(user).deliver_now
           head :ok

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::UsersController < Api::V1::BaseController
   def create
     user = User.new(user_params)
-    user.activation_token_expires_at = Time.zone.now.since(1.day)
     if user.save
       head :created
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,11 +25,6 @@ class User < ApplicationRecord
 
   enum role: { reviewer: 0, player: 1, admin: 2 }
 
-  def setup_activation_attributes
-    setup_activation
-    self.activation_token_expires_at = Time.zone.now.since(1.day)
-  end
-
   def activate_attributes
     activate!
     update_column(:activation_token_expires_at, nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ApplicationRecord
   include JwtToken
 
   before_save :email_downcase, if: -> { email_changed? }
-  before_update :setup_activation_attributes, if: -> { email_changed? }
-  after_update :send_activation_needed_email!, if: -> { previous_changes['email'].present? }
+  before_update :setup_activation, if: -> { email_changed? }
+  after_update :send_activation_needed_email!, if: -> { previous_changes["email"].present? }
 
   has_one :profile, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   before_save :email_downcase, if: -> { email_changed? }
   before_update :setup_activation, if: -> { email_changed? }
-  after_update :send_activation_needed_email!, if: -> { previous_changes["email"].present? }
+  after_update :send_activation_needed_email!, if: -> { previous_changes['email'].present? }
 
   has_one :profile, dependent: :destroy
 

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -335,7 +335,7 @@ Rails.application.config.sorcery.configure do |config|
     # How many seconds before the activation code expires. nil for never expires.
     # Default: `nil`
     #
-    user.activation_token_expiration_period = 86400
+    user.activation_token_expiration_period = 86_400
 
     # REQUIRED:
     # User activation mailer class.

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -335,7 +335,7 @@ Rails.application.config.sorcery.configure do |config|
     # How many seconds before the activation code expires. nil for never expires.
     # Default: `nil`
     #
-    # user.activation_token_expiration_period =
+    user.activation_token_expiration_period = 86400
 
     # REQUIRED:
     # User activation mailer class.

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,8 +10,4 @@ FactoryBot.define do
   trait :invalid do
     first_name { nil }
   end
-
-  trait :expired do
-    activation_token_expires_at { Time.zone.now.ago(2.day) }
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,6 +61,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include FactoryBot::Syntax::Methods
   config.include Requests::JsonHelpers, type: :request
   config.include UserSessions

--- a/spec/requests/api/v1/account_activations_spec.rb
+++ b/spec/requests/api/v1/account_activations_spec.rb
@@ -63,8 +63,11 @@ RSpec.describe 'Api::V1::AccountActivations', type: :request do
     end
 
     context '認証URLの有効期限が切れている場合' do #token_expired
-      before { get "/api/v1/account_activations/#{user.activation_token}/edit", headers: @header }
-      let!(:user) { create(:user, :expired) }
+      let!(:user) { create(:user) }
+      before do
+        travel_to(1.day.since)
+        get "/api/v1/account_activations/#{user.activation_token}/edit", headers: @header
+      end
 
       it '失敗して４００を返す' do
         expect(response.status).to eq(400)


### PR DESCRIPTION
## やったこと
activation_token_expiresはsorcery.rbに記述する場所があったのでそちらに記述
そのため、期限をセットしていたコードを削除
それに伴い、ユーザーモデル内を修正
rspecではtravel_toヘルパーを使用できるように設定
rubocopの指摘修正

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
特になし

## 動作確認
記述の場所を変えても期待通りに動くことを確認
ヘルパーが使用できることを確認

## その他
特になし
