### PR TITLE
修正 #9

### DIFF
--- a/app/controllers/api/v1/account_activations_controller.rb
+++ b/app/controllers/api/v1/account_activations_controller.rb
@@ -7,13 +7,13 @@ class Api::V1::AccountActivationsController < ApplicationController
           UserMailer.activation_needed_email(user).deliver_now
           head :ok
         else
-          render json: { email: '送信に失敗しました。もう一度お試しください。' }, status: :bad_request
+          render json: { errors: { email: '送信に失敗しました。もう一度お試しください。' } }, status: :bad_request
         end
       else
-        render json: { email: 'このメールアドレスは認証済みです' }, status: :bad_request
+        render json: { errors: { email: 'アカウントは認証済みです' } }, status: :bad_request
       end
     else
-      render json: { email: 'ユーザーが見つかりませんでした' }, status: :bad_request
+      render json: { errors: { email: 'ユーザーが見つかりませんでした' } }, status: :bad_request
     end
   end
 
@@ -28,9 +28,9 @@ class Api::V1::AccountActivationsController < ApplicationController
       else
         case failure_reason
         when :user_not_found
-          render json: { message: '既に認証済み又はURLが無効です' }, status: :bad_request
+          render json: { errors: { message: '既に認証済み又はURLが無効です' } }, status: :bad_request
         when :token_expired
-          render json: { message: '有効期限切れです' }, status: :bad_request
+          render json: { errors: { message: '有効期限切れです' } }, status: :bad_request
         end
       end
     end

--- a/app/javascript/components/pages/MySetting.vue
+++ b/app/javascript/components/pages/MySetting.vue
@@ -47,14 +47,14 @@
     </div>
     <!-- メール送信モーダル -->
     <v-dialog
-      v-model="dialog"
+      v-model="activationDialog"
       width="500"
       :persistent="true"
       scrollable
     >
       <send-activation-email
         :email="currentUser.email"
-        @click-close="dialog = false"
+        @click-close="activationDialog = false"
       />
     </v-dialog>
   </div>
@@ -80,7 +80,7 @@ export default {
   },
   data() {
     return {
-      dialog: false,
+      activationDialog: false,
       userEdit: {},
     }
   },

--- a/app/javascript/components/pages/MySetting.vue
+++ b/app/javascript/components/pages/MySetting.vue
@@ -127,21 +127,22 @@ export default {
       this.$store.dispatch("user/getCurrentUserFromAPI")
     },
     async updateProfile() {
-      const response = await this.$store.dispatch("user/updateCurrentUser", this.userEdit)
-      if (response.errors) {
-        this.$refs.profileEdit.setErrors(response.errors)
+      try {
+        const response = await this.$store.dispatch("user/updateCurrentUser", this.userEdit)
+        if (response.activationState === "pending") {
+          this.activationDialog = true
+        }
+        this.$store.dispatch("flash/setFlash", {
+          type: "success",
+          message: "更新しました"
+        })
+      } catch(error) {
+        this.$refs.profileEdit.setErrors(error.response.data.errors)
         return this.$store.dispatch("flash/setFlash", {
-                  type: "error",
-                  message: "フォームに不備があります"
-                })
+          type: "error",
+          message: "フォームに不備があります"
+        })
       }
-      if (response.activationState === "pending") {
-        this.dialog = true
-      }
-      this.$store.dispatch("flash/setFlash", {
-        type: "success",
-        message: "更新しました"
-      })
     },
     async deleteUser() {
       await this.$store.dispatch("user/deleteCurrentUser")

--- a/app/javascript/components/pages/Mypage.vue
+++ b/app/javascript/components/pages/Mypage.vue
@@ -169,25 +169,21 @@ export default {
       this.introductionForm = true
       this.setUserEdit()
     },
-    async getProfileData() {
-      const response = await this.$axios.get("/api/v1/profile")
-      this.profile = response.data
-      this.loading = true
-    },
     async updateIntroduction() {
-      const response = await this.$store.dispatch("user/updateCurrentUser", this.userEdit)
-      if (response.errors) {
-        this.$refs.introductionEdit.setErrors(response.errors)
+      try {
+        await this.$store.dispatch("user/updateCurrentUser", this.userEdit)
+        this.$store.dispatch("flash/setFlash", {
+          type: "success",
+          message: "更新しました"
+        })
+        this.introductionForm = false
+      } catch(error) {
+        this.$refs.introductionEdit.setErrors(error.response.data.errors)
         return this.$store.dispatch("flash/setFlash", {
           type: "error",
-          message: "文字数がオーバーしています"
+          message: "文字数をオーバーしています"
         })
       }
-      this.$store.dispatch("flash/setFlash", {
-        type: "success",
-        message: "更新しました"
-      })
-      this.introductionForm = false
     },
   }
 }

--- a/app/javascript/components/parts/SendActivationEmail.vue
+++ b/app/javascript/components/parts/SendActivationEmail.vue
@@ -112,11 +112,10 @@ export default {
           type: "success",
           message: "認証メールを送信しました"
         })
-      } catch(err) {
-        console.log(err.response.data.email);
+      } catch(error) {
         this.$store.dispatch("flash/setFlash", {
           type: "error",
-          message: err.response.data.email
+          message: Object.values(error.response.data.errors)[0]
         })
       }
     }

--- a/app/javascript/components/parts/TheResendActivationEmailDialog.vue
+++ b/app/javascript/components/parts/TheResendActivationEmailDialog.vue
@@ -112,10 +112,18 @@ export default {
         await this.$axios.post("/api/v1/account_activations", {
           email: this.email
         })
+        await this.$store.dispatch("flash/setFlash", {
+          type: "success",
+          message: "認証メールを送信しました"
+        })
         this.form = false
         this.sendEmail = true
-      } catch(err) {
-        this.$refs.observer.setErrors(err.response.data)
+      } catch(error) {
+        await this.$store.dispatch("flash/setFlash", {
+          type: "error",
+          message: Object.values(error.response.data.errors)[0]
+        })
+        this.$refs.observer.setErrors(error.response.data.errors)
       }
     }
   }

--- a/app/javascript/components/parts/TheResendActivationEmailDialog.vue
+++ b/app/javascript/components/parts/TheResendActivationEmailDialog.vue
@@ -10,7 +10,7 @@
       <v-btn
         icon
         :ripple="false"
-        @click="closeDialog"
+        @click="close"
       >
         <v-icon>
           mdi-close
@@ -79,7 +79,7 @@
     <send-activation-email
       v-if="sendEmail"
       :email="email"
-      @click-close="closeDialog"
+      @click-close="close"
     />
   </v-dialog>
 </template>
@@ -95,16 +95,16 @@ export default {
     return {
       dialog: false,
       email: "",
-      form: false,
+      form: true,
       sendEmail: false
     }
   },
   methods: {
     open() {
       this.dialog = true
-      this.form = true
     },
-    closeDialog() {
+    close() {
+      this.$refs.observer.reset()
       Object.assign(this.$data, this.$options.data())
     },
     async sendEmailData() {

--- a/app/javascript/store/user.js
+++ b/app/javascript/store/user.js
@@ -39,15 +39,11 @@ const actions = {
     }
   },
   async updateCurrentUser({ commit }, user) {
-    try {
-      const response = await axios.patch("/api/v1/users/current", {
-        user: user
-      })
-      commit("setCurrentUser", response.data.user)
-      return response.data.user
-    } catch(err) {
-      return err.response.data
-    }
+    const response = await axios.patch("/api/v1/users/current", {
+      user: user
+    })
+    commit("setCurrentUser", response.data.user)
+    return response.data.user
   },
   async deleteCurrentUser({ commit }) {
     await axios.delete("/api/v1/users/current")

--- a/spec/requests/api/v1/account_activations_spec.rb
+++ b/spec/requests/api/v1/account_activations_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Api::V1::AccountActivations', type: :request do
       end
 
       it 'エラーメッセージを返す' do
-        expect(json['email']).to eq('ユーザーが見つかりませんでした')
+        expect(json['errors']['email']).to eq('ユーザーが見つかりませんでした')
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe 'Api::V1::AccountActivations', type: :request do
       end
 
       it 'エラーメッセージを返す' do
-        expect(json['email']).to eq('このメールアドレスは認証済みです')
+        expect(json['errors']['email']).to eq('アカウントは認証済みです')
       end
     end
   end
@@ -74,7 +74,7 @@ RSpec.describe 'Api::V1::AccountActivations', type: :request do
       end
 
       it 'エラーメッセージを返す' do
-        expect(json['message']).to eq('有効期限切れです')
+        expect(json['errors']['message']).to eq('有効期限切れです')
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe 'Api::V1::AccountActivations', type: :request do
 
       it 'エラーメッセージを返す' do
         get "/api/v1/account_activations/#{user.activation_token}/edit", headers: @header
-        expect(json['message']).to eq('既に認証済み又はURLが無効です')
+        expect(json['errors']['message']).to eq('既に認証済み又はURLが無効です')
       end
     end
   end


### PR DESCRIPTION
## やったこと
レスポンスの修正
再送信モーダルで動的にメッセージを表示できるように修正
storeのユーザー更新を修正

## やらないこと
特になし

## できるようになること（ユーザ目線）
認証メール再送信でメッセージが表示されるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
レスポンスが修正されていることを確認
認証メール再送信でメッセージが表示されることを確認

## その他
特になし
