### PR TITLE
修正 #9

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,26 +1,21 @@
 class Api::V1::ProfilesController < ApplicationController
-  before_action :required_login, only: %i[create show update destroy]
+  before_action :required_login, only: %i[create update destroy]
 
   def create
     profile = current_user.build_profile(profile_params)
     if profile.save
       current_user.player!
-      render json: profile, include: '**', status: :created
+      render json: profile, status: :created
     else
       render json: { errors: profile.errors }, status: :unprocessable_entity
     end
-  end
-
-  def show
-    profile = current_user.profile
-    render json: profile, include: '**'
   end
 
   def update
     profile = current_user.profile
     profile.assign_attributes(profile_params)
     if profile.save
-      render json: profile, include: '**', status: :ok
+      render json: profile, status: :ok
     else
       render json: { errors: profile.errors }, status: :unprocessable_entity
     end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -1,28 +1,33 @@
 class ProfileSerializer < ActiveModel::Serializer
-  attributes :id, :position, :official_number, :practice_number, :career, :team_id, :group_id
-  belongs_to :team
-  belongs_to :group
+  attributes :position, :official_number, :practice_number, :career,
+             :team, :prefecture, :group, :category, :league, :team_id, :group_id
 
-  class TeamSerializer < ActiveModel::Serializer
-    attributes :name
-    belongs_to :prefecture
-
-    class PrefectureSerializer < ActiveModel::Serializer
-      attributes :id, :name
-    end
+  def team
+    object.team.name
   end
 
-  class GroupSerializer < ActiveModel::Serializer
-    attributes :name
-    belongs_to :category
+  def prefecture
+    {
+      id: object.team.prefecture.id,
+      name: object.team.prefecture.name
+    }
+  end
 
-    class CategorySerializer < ActiveModel::Serializer
-      attributes :id, :name
-      belongs_to :league
+  def group
+    object.group.name
+  end
 
-      class LeagueSerializer < ActiveModel::Serializer
-        attributes :id, :name
-      end
-    end
+  def category
+    {
+      id: object.group.category.id,
+      name: object.group.category.name,
+    }
+  end
+
+  def league
+    {
+      id: object.group.category.league.id,
+      name: object.group.category.league.name,
+    }
   end
 end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -20,14 +20,14 @@ class ProfileSerializer < ActiveModel::Serializer
   def category
     {
       id: object.group.category.id,
-      name: object.group.category.name,
+      name: object.group.category.name
     }
   end
 
   def league
     {
       id: object.group.category.league.id,
-      name: object.group.category.league.name,
+      name: object.group.category.league.name
     }
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :first_name, :last_name, :avatar, :birth_date, :role, :introduction,
              :email, :activation_state
+  has_one :profile
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
           end
         end
       end
-      resource :profile, only: %i[create show update destroy]
+      resource :profile, only: %i[create update destroy]
       resources :leagues, only: %i[index]
       resources :prefecture_teams, only: %i[index]
       resources :teams, only: %i[create]


### PR DESCRIPTION
## やったこと
プロフィールのレスポンスを修正
リーグ、チームは買いそうにしないでフラットなオブジェクトにする
ユーザーとプロフィールの情報を別々に取得していたが、アソシエーションを追加して、
一度のレスポンスで取得するように変更

## やらないこと
特になし

## できるようになること（ユーザ目線
一緒に取得することで、選手情報のロード時間が少し短くなる

## できなくなること（ユーザ目線）
特になし

## 動作確認
レスポンスが想定通りになっていることを確認

## その他
レビュワーかプレイヤーかはプロフィールがあるかどうかで判断できるのでroleを見直す

