### PR TITLE
修正 #9

### DIFF
--- a/app/controllers/api/v1/account_activations_controller.rb
+++ b/app/controllers/api/v1/account_activations_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::AccountActivationsController < ApplicationController
+class Api::V1::AccountActivationsController < Api::V1::BaseController
   def create
     if (user = User.find_by(email: params[:email]))
       if !user.activation_token.nil?

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -8,4 +8,10 @@ class Api::V1::BaseController < ApplicationController
 
     render json: { error: 'forbidden' }, status: :forbidden
   end
+
+  def check_activation
+    return if current_user.activation_state == 'active'
+
+    render json: { message: 'アカウントを認証してください' }, status: :forbidden
+  end
 end

--- a/app/controllers/api/v1/leagues_controller.rb
+++ b/app/controllers/api/v1/leagues_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::LeaguesController < ApplicationController
+class Api::V1::LeaguesController < Api::V1::BaseController
   def index
     leagues = League.preload(categories: [:groups])
     render json: leagues, each_serializer: LeagueSerializer, include: '**'

--- a/app/controllers/api/v1/prefecture_teams_controller.rb
+++ b/app/controllers/api/v1/prefecture_teams_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::PrefectureTeamsController < ApplicationController
+class Api::V1::PrefectureTeamsController < Api::V1::BaseController
   def index
     prefectures = Prefecture.preload(:teams)
     render json: prefectures, each_serializer: PrefectureSerializer

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ProfilesController < ApplicationController
   before_action :required_login, only: %i[create update destroy]
+  before_action :check_activation, only: %i[create update destroy]
 
   def create
     profile = current_user.build_profile(profile_params)
@@ -17,7 +18,7 @@ class Api::V1::ProfilesController < ApplicationController
     if profile.save
       render json: profile, status: :ok
     else
-      render json: { errors: profile.errors }, status: :unprocessable_entity
+      render json: { errors: profile.errors, message: 'フォームに不備があります' }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::ProfilesController < ApplicationController
+class Api::V1::ProfilesController < Api::V1::BaseController
   before_action :required_login, only: %i[create update destroy]
   before_action :check_activation, only: %i[create update destroy]
 

--- a/app/controllers/api/v1/relationships_controller.rb
+++ b/app/controllers/api/v1/relationships_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::RelationshipsController < Api::V1::BaseController
   before_action :required_login, only: %i[create destroy check]
+  before_action :check_activation, only: %i[create destroy]
 
   def create
     user = User.find(params[:user_id])

--- a/app/controllers/api/v1/relationships_controller.rb
+++ b/app/controllers/api/v1/relationships_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::RelationshipsController < ApplicationController
+class Api::V1::RelationshipsController < Api::V1::BaseController
   before_action :required_login, only: %i[create destroy check]
 
   def create

--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::TeamsController < ApplicationController
+class Api::V1::TeamsController < Api::V1::BaseController
   before_action :required_login, only: %i[create]
 
   def create

--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::TeamsController < Api::V1::BaseController
   before_action :required_login, only: %i[create]
+  before_action :check_activation, only: %i[create]
 
   def create
     team = Team.new(team_params)

--- a/app/controllers/api/v1/users/currents_controller.rb
+++ b/app/controllers/api/v1/users/currents_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Users::CurrentsController < Api::V1::BaseController
   before_action :required_login, only: %i[update destroy]
+  before_action :check_activation, only: %i[update destroy]
 
   def show
     render json: current_user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,6 @@ Rails.application.routes.draw do
       resources :prefecture_teams, only: %i[index]
       resources :teams, only: %i[create]
       resources :account_activations, only: %i[create edit]
-
       post '/login', to: 'user_sessions#create'
       delete '/logout', to: 'user_sessions#destroy'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,9 @@ Rails.application.routes.draw do
             resource :current, only: %i[show update destroy]
           end
         end
-        resource :relationships, only: %i[create destroy]
-        get 'relationships/check', to: 'relationships#check'
+        resource :relationships, only: %i[create destroy] do
+          get :check, on: :member
+        end
       end
       resource :profile, only: %i[create update destroy]
       resources :leagues, only: %i[index]


### PR DESCRIPTION
## やったこと
api/v1以下のファイルは全てbase_controllerを継承するように修正
teams_controller、profiles_controller、relationships_controller、currents_controller
のcreate, update, destroyではアカウントが有効になっていないと処理できないように修正
relationships/checkをmemberに修正

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
アカウントが有効でないとリソースを作成、更新、削除できなくなる。(全てではない)

## 動作確認
アカウントが有効になっていないとエラーが発生することを確認

## その他
特になし
