### PR TITLE
修正 #2

### DIFF
--- a/app/javascript/components/parts/ReviewCard.vue
+++ b/app/javascript/components/parts/ReviewCard.vue
@@ -8,7 +8,7 @@
         <v-list-item-avatar
           size="45"
           class="mr-2"
-          style="cursor: pointer;"
+          :style="!!reviewUserId ? 'cursor: pointer;' : ''"
           @click="pushUserPage"
         >
           <v-img
@@ -20,12 +20,12 @@
             <span :class="$vuetify.breakpoint.mobile ? 'text-body-2 font-weight-bold' : 'text-body-2 font-weight-bold'">
               <span
                 v-cloak
-                style="cursor: pointer;"
+                :style="!!reviewUserId ? 'cursor: pointer;' : ''"
                 @click="pushUserPage"
               >
                 {{ fullName }}
               </span>
-              <span v-if="user.role === 'player'">
+              <span v-if="user.role === 'player' && !!reviewUserId">
                 さんのレビュー
               </span>
               <span v-if="user.role === 'reviewer'">

--- a/app/javascript/components/parts/ReviewCard.vue
+++ b/app/javascript/components/parts/ReviewCard.vue
@@ -115,6 +115,7 @@ export default {
   },
   methods: {
     pushUserPage() {
+      if (!this.reviewUserId) return
       if (this.currentUser.id === this.reviewUserId) {
         this.$router.push({ name: "profile" })
       } else {

--- a/app/javascript/components/parts/ReviewCard.vue
+++ b/app/javascript/components/parts/ReviewCard.vue
@@ -106,9 +106,6 @@ export default {
   },
   computed: {
     ...mapGetters({ currentUser: "user/currentUser" }),
-    rate() {
-      return +this.review.rate
-    },
     fullName() {
       return this.user.role === 'player' ? this.review.reviewer.fullName : this.review.reviewee.fullName
     },

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -3,7 +3,7 @@ class Review < ApplicationRecord
   belongs_to :reviewee, class_name: 'User'
 
   validates :rate, presence: true, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }
-  validates :game_date, presence: true, format: { with: /\d{4}-\d{2}-\d{2}/ }, uniqueness: { scope: [:reviewer, :reviewee] }
+  validates :game_date, presence: true, format: { with: /\d{4}-\d{2}-\d{2}/ }, uniqueness: { scope: %i[reviewer reviewee] }
   validates :privacy, presence: true
   validates :content, presence: true, length: { maximum: 10_000 }
 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -3,7 +3,7 @@ class Review < ApplicationRecord
   belongs_to :reviewee, class_name: 'User'
 
   validates :rate, presence: true, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }
-  validates :game_date, presence: true, format: { with: /\d{4}-\d{2}-\d{2}/ }
+  validates :game_date, presence: true, format: { with: /\d{4}-\d{2}-\d{2}/ }, uniqueness: { scope: [:reviewer, :reviewee] }
   validates :privacy, presence: true
   validates :content, presence: true, length: { maximum: 10_000 }
 

--- a/db/migrate/20210724091155_add_unique_index_to_reviews.rb
+++ b/db/migrate/20210724091155_add_unique_index_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToReviews < ActiveRecord::Migration[6.1]
+  def change
+    add_index :reviews, [:reviewer_id, :reviewee_id, :game_date], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_22_141906) do
+ActiveRecord::Schema.define(version: 2021_07_24_091155) do
 
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2021_07_22_141906) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["reviewee_id"], name: "index_reviews_on_reviewee_id"
+    t.index ["reviewer_id", "reviewee_id", "game_date"], name: "index_reviews_on_reviewer_id_and_reviewee_id_and_game_date", unique: true
     t.index ["reviewer_id"], name: "index_reviews_on_reviewer_id"
   end
 


### PR DESCRIPTION
## やったこと
退会したユーザーのページには遷移できないように修正
試合日、レビューイ、レビューワーの組み合わせをユニークに修正

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
退会したユーザーをクリックすることができなくなる

## 動作確認
退会したユーザーのページに遷移できないことを確認
ユニーク制約がかかっていることを確認

## その他
特になし
