### PR TITLE
修正 #199

### DIFF
--- a/app/controllers/api/v1/account_activations_controller.rb
+++ b/app/controllers/api/v1/account_activations_controller.rb
@@ -27,10 +27,12 @@ class Api::V1::AccountActivationsController < Api::V1::BaseController
         redirect_to root_path
       else
         case failure_reason
+        when :invalid_token
+          render json: { message: '認証メールの取得からやり直してください' }, status: :bad_request
         when :user_not_found
-          render json: { errors: { message: '既に認証済み又はURLが無効です' } }, status: :bad_request
+          render json: { message: '認証済み又はURLが無効です' }, status: :bad_request
         when :token_expired
-          render json: { errors: { message: '有効期限切れです' } }, status: :bad_request
+          render json: { message: '認証メールの取得からやり直してください' }, status: :bad_request
         end
       end
     end

--- a/app/controllers/api/v1/user_sessions_controller.rb
+++ b/app/controllers/api/v1/user_sessions_controller.rb
@@ -8,11 +8,11 @@ class Api::V1::UserSessionsController < Api::V1::BaseController
       else
         case failure_reason
         when :invalid_login
-          render json: { errors: { email: 'メールアドレスが間違っています' }, message: 'メールアドレスが間違っています' }, status: :bad_request
+          render json: { errors: { email: 'メールアドレスが間違っています' }, message: 'フォームに不備があります' }, status: :bad_request
         when :inactive
           render json: { status: 'inactive', message: 'アカウントを認証してください' }, status: :bad_request
         when :invalid_password
-          render json: { errors: { password: 'パスワードが間違っています' }, message: 'パスワードが間違っています' }, status: :bad_request
+          render json: { errors: { password: 'パスワードが間違っています' }, message: 'フォームに不備があります' }, status: :bad_request
         end
       end
     end

--- a/app/controllers/api/v1/users/current/password_changes_controller.rb
+++ b/app/controllers/api/v1/users/current/password_changes_controller.rb
@@ -1,4 +1,7 @@
-class Api::V1::Users::Current::PasswordChangesController < ApplicationController
+class Api::V1::Users::Current::PasswordChangesController < Api::V1::BaseController
+  before_action :required_login, only: %i[update]
+  before_action :check_activation, only: %i[update]
+
   def update
     if current_user.valid_password?(params[:current_password])
       current_user.assign_attributes(user_params)

--- a/app/javascript/components/parts/Login.vue
+++ b/app/javascript/components/parts/Login.vue
@@ -23,7 +23,10 @@
                 <ValidationProvider
                   v-slot="{ errors }"
                   vid="email"
-                  rules="required"
+                  :rules="{
+                    required: true,
+                    formFormat: /^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/i
+                  }"
                   name="メールアドレス"
                 >
                   <v-text-field
@@ -43,7 +46,7 @@
                 <ValidationProvider
                   v-slot="{ errors }"
                   vid="password"
-                  rules="required"
+                  :rules="{ required: true, min: 8, formFormat: /^(?=.*?[a-z])(?=.*?\d)[a-z\d]{8,}$/i }"
                   name="パスワード"
                 >
                   <v-text-field

--- a/spec/requests/api/v1/account_activations_spec.rb
+++ b/spec/requests/api/v1/account_activations_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Api::V1::AccountActivations', type: :request do
       end
 
       it 'エラーメッセージを返す' do
-        expect(json['errors']['message']).to eq('有効期限切れです')
+        expect(json['message']).to eq('認証メールの取得からやり直してください')
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe 'Api::V1::AccountActivations', type: :request do
 
       it 'エラーメッセージを返す' do
         get "/api/v1/account_activations/#{user.activation_token}/edit", headers: @header
-        expect(json['errors']['message']).to eq('既に認証済み又はURLが無効です')
+        expect(json['message']).to eq('認証済み又はURLが無効です')
       end
     end
   end


### PR DESCRIPTION
## やったこと
エラー時のレスポンスの修正
それに伴いテストの修正
ログイン時にもフロント側でバリデーションをかけるように設定

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
特になし

## 動作確認
エラー時に想定通りのレスポンスが返ってくることを確認
ログイン時にもバリデーションがかかることを確認

## その他
特になし
