### PR TITLE
追加と修正 #12

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -3,7 +3,8 @@
     <the-header />
     <v-main style="background: #FAFAFA;">
       <the-flash-message />
-      <router-view />
+      <not-found v-if="isNotFound" />
+      <router-view v-if="!isNotFound" />
     </v-main>
     <the-footer />
   </v-app>
@@ -13,12 +14,23 @@
 import TheHeader from "./components/globals/TheHeader"
 import TheFlashMessage from "./components/globals/TheFlashMessage"
 import TheFooter from "./components/globals/TheFooter"
+import NotFound from "./components/pages/NotFound"
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
     TheHeader,
     TheFlashMessage,
-    TheFooter
+    TheFooter,
+    NotFound
   },
+  computed: {
+    ...mapGetters({ isNotFound: "notFound/isNotFound" })
+  },
+  watch: {
+    $route() {
+      this.$store.dispatch("notFound/setNotFound", false)
+    }
+  }
 }
 </script>

--- a/app/javascript/components/pages/CategoryPlayers.vue
+++ b/app/javascript/components/pages/CategoryPlayers.vue
@@ -1,0 +1,60 @@
+<template>
+  <div
+    v-if="loading"
+    class="league"
+  >
+    <the-bread-crumb
+      :bread-crumbs="breadCrumbs"
+    />
+  </div>
+</template>
+
+<script>
+import Transform from "../../packs/league-transform"
+import TheBreadCrumb from "../globals/TheBreadCrumb"
+
+export default {
+  components: {
+    TheBreadCrumb
+  },
+  data() {
+    return {
+      category: {},
+      loading: false
+    }
+  },
+  computed: {
+    breadCrumbs() {
+      return [
+        {
+          text: "TOP",
+          to: "/",
+          disabled: false,
+        },
+        {
+          text: this.category.league.name,
+          to: `/${this.$route.params.league}`,
+          disabled: false,
+        },
+        {
+          text: this.category.name,
+          to: this.$route.path,
+          disabled: true
+        }
+      ]
+    }
+  },
+  created() {
+    this.getCategory()
+  },
+  methods: {
+    async getCategory() {
+      const leagueId = Transform.getLeagueId(this.$route.params.league)
+      const response = await this.$axios.get(`/api/v1/${leagueId}/categories/${this.$route.params.categoryId}`)
+      this.category = response.data.category
+      this.loading = true
+      console.log(this.category.league.name);
+    }
+  }
+}
+</script>

--- a/app/javascript/components/pages/GroupPlayers.vue
+++ b/app/javascript/components/pages/GroupPlayers.vue
@@ -1,0 +1,67 @@
+<template>
+  <div
+    v-if="loading"
+    class="league"
+  >
+    <the-bread-crumb
+      :bread-crumbs="breadCrumbs"
+    />
+  </div>
+</template>
+
+<script>
+import Transform from "../../packs/league-transform"
+import TheBreadCrumb from "../globals/TheBreadCrumb"
+
+export default {
+  components: {
+    TheBreadCrumb
+  },
+  data() {
+    return {
+      group: {},
+      loading: false
+    }
+  },
+  computed: {
+    breadCrumbs() {
+      return [
+        {
+          text: "TOP",
+          to: "/",
+          disabled: false,
+        },
+        {
+          text: this.group.league.name,
+          to: `/${this.$route.params.league}`,
+          disabled: false,
+        },
+        {
+          text: this.group.category.name,
+          to: `/${this.$route.params.league}/${this.$route.params.categoryId}`,
+          disabled: false
+        },
+        {
+          text: this.group.name,
+          to: this.$route.path,
+          disabled: true
+        }
+      ]
+    }
+  },
+  created() {
+    this.getGroup()
+  },
+  methods: {
+    async getGroup() {
+      const leagueId = Transform.getLeagueId(this.$route.params.league)
+      const response = await this.$axios.get(
+        `/api/v1/${leagueId}/${this.$route.params.categoryId}/groups/${this.$route.params.groupId}`
+      )
+      this.group = response.data.group
+      this.loading = true
+      console.log(this.group);
+    }
+  }
+}
+</script>

--- a/app/javascript/components/pages/LeaguePlayers.vue
+++ b/app/javascript/components/pages/LeaguePlayers.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="league">
+    <the-bread-crumb
+      :bread-crumbs="breadCrumbs"
+    />
+    <v-container>
+      <v-row>
+        <v-col
+          cols="12"
+          lg="6"
+        />
+        <v-col
+          cols="12"
+          lg="6"
+        >
+          <div class="font-weight-bold " />
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+
+<script>
+import Transform from "../../packs/league-transform"
+import TheBreadCrumb from "../globals/TheBreadCrumb"
+
+export default {
+  components: {
+    TheBreadCrumb
+  },
+  data() {
+    return {
+      players: [],
+      league: {},
+    }
+  },
+  computed: {
+    breadCrumbs() {
+      return [
+        {
+          text: "TOP",
+          to: "/",
+          disabled: false,
+        },
+        {
+          text: this.league.name,
+          to: this.$route.path,
+          disabled: false,
+        },
+      ]
+    }
+  },
+  async created() {
+    this.getLeague()
+    this.getPlayers()
+  },
+  methods: {
+    async getPlayers() {
+      const leagueId = Transform.getLeagueId(this.$route.params.league)
+      const response = await this.$axios.get(`/api/v1/leagues/${leagueId}/users`)
+    },
+    async getLeague() {
+      const leagueId = Transform.getLeagueId(this.$route.params.league)
+      const response = await this.$axios.get(`/api/v1/leagues/${leagueId}`)
+      this.league = response.data.league
+    },
+  }
+}
+</script>
+
+<style scoped>
+  .league {
+    max-width: 1050px;
+    margin: 0 auto;
+  }
+</style>

--- a/app/javascript/components/pages/MySetting.vue
+++ b/app/javascript/components/pages/MySetting.vue
@@ -112,6 +112,10 @@ export default {
   created() {
     this.dupUser()
   },
+  mounted() {
+    if (this.$route.params.type.includes("account") || this.$route.params.type.includes("profile") || this.$route.params.type.includes("player")) return
+    this.$store.dispatch("notFound/setNotFound", true)
+  },
   methods: {
     dupUser() {
       this.userEdit = { ...this.currentUser }

--- a/app/javascript/components/pages/NotFound.vue
+++ b/app/javascript/components/pages/NotFound.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="content pt-10 pb-5">
+    <h1 class="display-3 font-weight-thin">
+      404 NotFound
+    </h1>
+    <div class="mt-10 mb-10">
+      <p>お探しのページが見つかりませんでした。</p>
+      <p>
+        一時的にアクセスができない状況にあるか
+        <br class="d-flex d-sm-none">移動もしくは削除された可能性があります。
+      </p>
+      <p>URLにお間違いがないか再度ご確認ください。</p>
+    </div>
+    <v-btn
+      color="primary"
+      depressed
+      :to="{ name: 'top' }"
+    >
+      <v-icon left>
+        mdi-exit-run
+      </v-icon>トップページに戻る
+    </v-btn>
+  </div>
+</template>
+
+<style scoped>
+.content {
+  margin: 0 auto;
+  max-width: 400px;
+}
+</style>

--- a/app/javascript/components/parts/TheProfileWrapper.vue
+++ b/app/javascript/components/parts/TheProfileWrapper.vue
@@ -159,6 +159,11 @@ export default {
     this.checkFollow()
     this.getReviews()
   },
+  mounted() {
+    if (!this.$route.params.type) return
+    if (this.$route.params.type.includes("following") || this.$route.params.type.includes("followers")) return
+    this.$store.dispatch("notFound/setNotFound", true)
+  },
   methods: {
     openIntroduction() {
       this.introductionForm = true

--- a/app/javascript/packs/league-transform.js
+++ b/app/javascript/packs/league-transform.js
@@ -1,0 +1,318 @@
+const leagueNameEigo = (leagueName) => {
+  let eigo = ""
+  switch (leagueName) {
+  case "プレミアリーグ":
+    eigo = "premier"
+    break
+  case "プリンスリーグ":
+    eigo =  "prince"
+    break
+  case "ルーキーリーグ":
+    eigo =  "rookie"
+    break
+  case "北海道":
+    eigo = "hokkaido"
+    break
+  case "青森":
+    eigo = "aomori"
+    break
+  case "岩手":
+    eigo =  "iwate"
+    break
+  case "宮城":
+    eigo =  "miyagi"
+    break
+  case "秋田":
+    eigo = "akita"
+    break
+  case "山形":
+    eigo = "yamagata"
+    break
+  case "福島":
+    eigo = "fukushima"
+    break
+  case "茨城":
+    eigo =  "ibaraki"
+    break
+  case "栃木":
+    eigo =  "tochigi"
+    break
+  case "群馬":
+    eigo = "gunma"
+    break
+  case "埼玉":
+    eigo = "saitama"
+    break
+  case "千葉":
+    eigo =  "chiba"
+    break
+  case "東京":
+    eigo =  "tokyo"
+    break
+  case "神奈川":
+    eigo = "kanagawa"
+    break
+  case "新潟":
+    eigo = "niigata"
+    break
+  case "富山":
+    eigo =  "toyama"
+    break
+  case "石川":
+    eigo =  "ishikawa"
+    break
+  case "福井":
+    eigo = "fukui"
+    break
+  case "山梨":
+    eigo = "yamanashi"
+    break
+  case "長野":
+    eigo =  "nagano"
+    break
+  case "岐阜":
+    eigo =  "gifu"
+    break
+  case "静岡":
+    eigo = "shizuoka"
+    break
+  case "愛知":
+    eigo = "aichi"
+    break
+  case "三重":
+    eigo =  "mie"
+    break
+  case "滋賀":
+    eigo =  "shiga"
+    break
+  case "京都":
+    eigo = "kyoto"
+    break
+  case "大阪":
+    eigo = "osaka"
+    break
+  case "兵庫":
+    eigo =  "hyogo"
+    break
+  case "奈良":
+    eigo =  "nara"
+    break
+  case "和歌山":
+    eigo = "wakayama"
+    break
+  case "鳥取":
+    eigo = "tottori"
+    break
+  case "島根":
+    eigo =  "shimane"
+    break
+  case "岡山":
+    eigo =  "okayama"
+    break
+  case "広島":
+    eigo = "hiroshima"
+    break
+  case "山口":
+    eigo =  "yamaguchi"
+    break
+  case "徳島":
+    eigo =  "tokushima"
+    break
+  case "香川":
+    eigo = "kagawa"
+    break
+  case "愛媛":
+    eigo = "ehime"
+    break
+  case "高知":
+    eigo =  "kochi"
+    break
+  case "福岡":
+    eigo =  "fukuoka"
+    break
+  case "佐賀":
+    eigo = "saga"
+    break
+  case "長崎":
+    eigo =  "nagasaki"
+    break
+  case "熊本":
+    eigo =  "kumamoto"
+    break
+  case "大分":
+    eigo = "oita"
+    break
+  case "宮崎":
+    eigo = "miyazaki"
+    break
+  case "鹿児島":
+    eigo =  "kagoshima"
+    break
+  case "沖縄":
+    eigo =  "okinawa"
+    break
+  }
+  return eigo
+}
+
+const getLeagueId = (leagueEigo) => {
+  let id = ""
+  switch (leagueEigo) {
+  case "premier":
+    id = 1
+    break
+  case "prince":
+    id = 2
+    break
+  case "rookie":
+    id = 3
+    break
+  case "hokkaido":
+    id = 4
+    break
+  case "aomori":
+    id = 5
+    break
+  case "iwate":
+    id = 6
+    break
+  case "miyagi":
+    id = 7
+    break
+  case "akita":
+    id = 8
+    break
+  case "yamagata":
+    id = 9
+    break
+  case "fukushima":
+    id = 10
+    break
+  case "ibaraki":
+    id = 11
+    break
+  case "tochigi":
+    id = 12
+    break
+  case "gunma":
+    id = 13
+    break
+  case "saitama":
+    id = 14
+    break
+  case "chiba":
+    id = 15
+    break
+  case "tokyo":
+    id = 16
+    break
+  case "kanagawa":
+    id = 17
+    break
+  case "niigata":
+    id = 18
+    break
+  case "toyama":
+    id = 19
+    break
+  case "ishikawa":
+    id = 20
+    break
+  case "fukui":
+    id = 21
+    break
+  case "yamanashi":
+    id = 22
+    break
+  case "nagano":
+    id = 23
+    break
+  case "gifu":
+    id = 24
+    break
+  case "shizuoka":
+    id = 25
+    break
+  case "aichi":
+    id = 26
+    break
+  case "mie":
+    id = 27
+    break
+  case "shiga":
+    id = 28
+    break
+  case "kyoto":
+    id = 29
+    break
+  case "osaka":
+    id = 30
+    break
+  case "hyogo":
+    id = 31
+    break
+  case "nara":
+    id = 32
+    break
+  case "wakayama":
+    id = 33
+    break
+  case "tottori":
+    id = 34
+    break
+  case "shimane":
+    id = 35
+    break
+  case "okayama":
+    id = 36
+    break
+  case "hiroshima":
+    id = 37
+    break
+  case "yamaguchi":
+    id = 38
+    break
+  case "tokushima":
+    id = 39
+    break
+  case "kagawa":
+    id = 40
+    break
+  case "ehime":
+    id = 41
+    break
+  case "kochi":
+    id = 42
+    break
+  case "fukuoka":
+    id = 43
+    break
+  case "saga":
+    id = 44
+    break
+  case "nagasaki":
+    id = 45
+    break
+  case "kumamoto":
+    id = 46
+    break
+  case "oita":
+    id = 47
+    break
+  case "miyazaki":
+    id = 48
+    break
+  case "kagoshima":
+    id = 49
+    break
+  case "okinawa":
+    id = 50
+    break
+  }
+  return id
+}
+
+export default {
+  leagueNameEigo,
+  getLeagueId
+}

--- a/app/javascript/plugins/axios.js
+++ b/app/javascript/plugins/axios.js
@@ -1,4 +1,5 @@
 import Axios from "axios"
+import store from "../store"
 
 const instance = Axios.create()
 
@@ -11,4 +12,15 @@ instance.interceptors.request.use(request => {
   return request
 })
 
+instance.interceptors.response.use(
+  response => response,
+  error => {
+    const response = error.response
+    const status = response === undefined ? undefined : response.status
+    if (status === 404) {
+      store.dispatch("notFound/setNotFound", true)
+    }
+    return Promise.reject(error)
+  }
+)
 export default instance

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -7,6 +7,10 @@ import Mypage from "../components/pages/Mypage"
 import MySetting from "../components/pages/MySetting"
 import User from "../components/pages/User"
 import PasswordReset from "../components/pages/PasswordReset"
+import LeaguePlayers from "../components/pages/LeaguePlayers"
+import CategoryPlayers from "../components/pages/CategoryPlayers"
+import GroupPlayers from "../components/pages/GroupPlayers"
+import NotFound from "../components/pages/NotFound"
 
 const routes = [
   {
@@ -37,9 +41,35 @@ const routes = [
     component: User,
   },
   {
+    path: "/:league/:categoryId/:groupId/:userId/:type?",
+    name: "playerProfile",
+    component: User
+  },
+  {
     path: "/account/:type",
     name: "passwordReset",
     component: PasswordReset
+  },
+  {
+    path: "/:league",
+    name: "leaguePlayer",
+    component: LeaguePlayers
+  },
+  {
+    path: "/:league/:categoryId",
+    name: "categoryPlayer",
+    component: CategoryPlayers
+  },
+  {
+    path: "/:league/:categoryId/:groupId",
+    name: "groupPlayer",
+    component: GroupPlayers
+  },
+  {
+    name: "notFound",
+    path: "*",
+    component: NotFound,
+    meta: { title: "お探しのページは見つかりませんでした" }
   }
 ]
 

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -2,6 +2,7 @@ import Vue from "vue"
 import Vuex from "vuex"
 import user from "./user"
 import flash from "./flash"
+import notFound from "./not-found"
 
 Vue.use(Vuex)
 
@@ -9,5 +10,6 @@ export default new Vuex.Store({
   modules: {
     user,
     flash,
+    notFound
   }
 })

--- a/app/javascript/store/not-found.js
+++ b/app/javascript/store/not-found.js
@@ -1,0 +1,27 @@
+const state = () => ({
+  notFound: false
+})
+
+const getters = {
+  isNotFound: state => state.notFound
+}
+
+const mutations = {
+  setNotFound(state, val) {
+    state.notFound = val
+  }
+}
+
+const actions = {
+  setNotFound({ commit }, val) {
+    commit("setNotFound", val)
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,20 +29,27 @@ Rails.application.routes.draw do
           end
         end
       end
-      resources :leagues, only: %i[index show] do
-        resources :users, only: %i[index], module: :leagues
-        resources :categories, only: %i[show] do
-          resources :users, only: %i[index], module: :categories
-          resources :groups, only: %i[show] do
-            resources :users, only: %i[index], module: :groups
-          end
-        end
-      end
       resources :password_resets, only: %i[create edit update]
       resources :reviews, only: %i[index]
+
+      resources :leagues, only: %i[index show] do
+        resources :users, only: %i[index], module: :leagues
+      end
+
+      resources :categories, only: [] do
+        resources :users, only: %i[index], module: :categories
+      end
+
+      resources :groups, only: [] do
+        resources :users, only: %i[index], module: :groups
+      end
+
       resources :prefecture_teams, only: %i[index]
       resources :teams, only: %i[create]
       resources :account_activations, only: %i[create edit]
+
+      get ':league_id/categories/:id', to: 'categories#show'
+      get ':league_id/:category_id/groups/:id', to: 'groups#show'
       post '/login', to: 'user_sessions#create'
       delete '/logout', to: 'user_sessions#destroy'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,12 +31,12 @@ Rails.application.routes.draw do
       end
       resources :leagues, only: %i[index show] do
         resources :users, only: %i[index], module: :leagues
-      end
-      resources :categories, only: %i[show] do
-        resources :users, only: %i[index], module: :categories
-      end
-      resources :groups, only: %i[show] do
-        resources :users, only: %i[index], module: :groups
+        resources :categories, only: %i[show] do
+          resources :users, only: %i[index], module: :categories
+          resources :groups, only: %i[show] do
+            resources :users, only: %i[index], module: :groups
+          end
+        end
       end
       resources :password_resets, only: %i[create edit update]
       resources :reviews, only: %i[index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
   root to: 'home#index'
-
   get 'account/password_reset', to: 'home#index'
   get 'account/send_password_reset', to: 'home#index'
 
@@ -31,23 +30,18 @@ Rails.application.routes.draw do
       end
       resources :password_resets, only: %i[create edit update]
       resources :reviews, only: %i[index]
-
       resources :leagues, only: %i[index show] do
         resources :users, only: %i[index], module: :leagues
       end
-
       resources :categories, only: [] do
         resources :users, only: %i[index], module: :categories
       end
-
       resources :groups, only: [] do
         resources :users, only: %i[index], module: :groups
       end
-
       resources :prefecture_teams, only: %i[index]
       resources :teams, only: %i[create]
       resources :account_activations, only: %i[create edit]
-
       get ':league_id/categories/:id', to: 'categories#show'
       get ':league_id/:category_id/groups/:id', to: 'groups#show'
       post '/login', to: 'user_sessions#create'


### PR DESCRIPTION
## やったこと
404ページを表示できるようにビューを作成
レスポンスのステータスで404を制御するようにaxios.jsに設定

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
定義していないページに遷移できない

## 動作確認
404ページが表示されることを確認

## その他
特になし
