### PR TITLE
追加と修正 #12

### DIFF
--- a/app/controllers/api/v1/groups/users_controller.rb
+++ b/app/controllers/api/v1/groups/users_controller.rb
@@ -3,9 +3,4 @@ class Api::V1::Groups::UsersController < Api::V1::BaseController
     users = User.joins(profile: :group).merge(Group.where(id: params[:group_id]))
     render json: users
   end
-
-  def show
-    user = League.find(params[:league_id]).categories.find(params[:category_id]).groups.find(params[:group_id]).profiles.find_by(user_id: params[:id]).user
-    render json: user
-  end
 end

--- a/app/javascript/components/pages/CategoryPlayers.vue
+++ b/app/javascript/components/pages/CategoryPlayers.vue
@@ -30,12 +30,21 @@ import PlayerList from "../parts/PlayerList"
 
 export default {
   components: {
-    TheBreadCrumb
+    TheBreadCrumb,
+    PlayerSearch,
+    PlayerList
+  },
+  beforeRouteUpdate(to, from, next) {
+    next()
+    this.getCategory()
+    this.getPlayers()
   },
   data() {
     return {
-      players: [],
+      users: [],
       category: {},
+      categories: [],
+      teams: [],
       loading: false
     }
   },
@@ -49,7 +58,7 @@ export default {
         },
         {
           text: this.category.league.name,
-          to: `/${this.$route.params.league}`,
+          to: `/${Transform.leagueNameEigo(this.category.league.name)}`,
           disabled: false,
         },
         {
@@ -61,20 +70,43 @@ export default {
     }
   },
   created() {
-    this.getCategory()
-    this.getPlayers()
+    this.getData()
   },
   methods: {
-     async getPlayers() {
+    async getData() {
+      await this.getCategory()
+      await this.getPlayers()
+      await this.getCategories()
+      await this.getTeams()
+      this.loading = true
+    },
+    async getPlayers() {
       const response = await this.$axios.get(`/api/v1/categories/${this.$route.params.categoryId}/users`)
-      this.players = response.data.users
+      this.users = response.data.users
     },
     async getCategory() {
-      const leagueId = Transform.getLeagueId(this.$route.params.league)
-      const response = await this.$axios.get(`/api/v1/${leagueId}/categories/${this.$route.params.categoryId}`)
+      const response = await this.$axios.get(`/api/v1/categories/${this.$route.params.categoryId}`)
       this.category = response.data.category
-      this.loading = true
+    },
+    async getTeams() {
+      const response = await this.$axios.get(`/api/v1/categories/${this.category.id}/teams`)
+      this.teams = response.data.teams
+      const unspecified = { name: "指定なし", id: 0 }
+      this.teams.unshift(unspecified)
+    },
+    async getCategories() {
+      const leagueEigo = Transform.leagueNameEigo(this.category.league.name)
+      const leagueId = Transform.getLeagueId(leagueEigo)
+      const response = await this.$axios.get(`/api/v1/leagues/${leagueId}/categories`)
+      this.categories = response.data.categories
     }
   }
 }
 </script>
+
+<style scoped>
+  .league {
+    max-width: 1050px;
+    margin: 0 auto;
+  }
+</style>

--- a/app/javascript/components/pages/CategoryPlayers.vue
+++ b/app/javascript/components/pages/CategoryPlayers.vue
@@ -6,12 +6,27 @@
     <the-bread-crumb
       :bread-crumbs="breadCrumbs"
     />
+    <v-container>
+      <v-row>
+        <player-search
+          :league="category"
+          :leagues="categories"
+          :teams="teams"
+        />
+        <player-list
+          :users="users"
+          :league="category"
+        />
+      </v-row>
+    </v-container>
   </div>
 </template>
 
 <script>
 import Transform from "../../packs/league-transform"
 import TheBreadCrumb from "../globals/TheBreadCrumb"
+import PlayerSearch from "../parts/PlayerSearch"
+import PlayerList from "../parts/PlayerList"
 
 export default {
   components: {

--- a/app/javascript/components/pages/GroupPlayers.vue
+++ b/app/javascript/components/pages/GroupPlayers.vue
@@ -6,12 +6,27 @@
     <the-bread-crumb
       :bread-crumbs="breadCrumbs"
     />
+    <v-container>
+      <v-row>
+        <player-search
+          :league="group"
+          :leagues="groups"
+          :teams="teams"
+        />
+        <player-list
+          :users="users"
+          :league="group"
+        />
+      </v-row>
+    </v-container>
   </div>
 </template>
 
 <script>
 import Transform from "../../packs/league-transform"
 import TheBreadCrumb from "../globals/TheBreadCrumb"
+import PlayerSearch from "../parts/PlayerSearch"
+import PlayerList from "../parts/PlayerList"
 
 export default {
   components: {

--- a/app/javascript/components/pages/LeaguePlayers.vue
+++ b/app/javascript/components/pages/LeaguePlayers.vue
@@ -6,252 +6,19 @@
     <the-bread-crumb
       :bread-crumbs="breadCrumbs"
     />
-    <div class="players">
-      <v-container>
-        <v-row>
-          <v-col
-            v-if="!$vuetify.breakpoint.mobile"
-            cols="12"
-            lg="4"
-          >
-            <v-card
-              width="300"
-              outlined
-            >
-              <v-card-text class="mt-2">
-                <v-icon color="primary">
-                  mdi-map-marker
-                </v-icon>
-                <span
-                  class="font-weight-bold black--text"
-                  style="position: relative; top: 2px;"
-                >
-                  リーグから探す
-                </span>
-              </v-card-text>
-              <v-menu
-                v-model="menu"
-                :close-on-content-click="false"
-                :nudge-width="200"
-                offset-x
-              >
-                <template #activator="{ on, attrs }">
-                  <v-card-actions
-                    class="font-weight-bold text-subtitle-1 blue--text text--darken-2 py-0 ml-1 pl-4"
-                    style="cursor: pointer;"
-                    v-bind="attrs"
-                    v-on="on"
-                  >
-                    {{ league.name }}
-                    <v-spacer />
-                    <v-icon>
-                      mdi-chevron-right
-                    </v-icon>
-                  </v-card-actions>
-                </template>
-                <v-card
-                  color="#FAFAFA"
-                  max-width="500"
-                >
-                  <v-card-text>
-                    <v-chip-group
-                      column
-                    >
-                      <v-chip
-                        outlined
-                        small
-                      >
-                        全国
-                      </v-chip>
-                      <v-chip
-                        v-for="filterLeague in filterLeagues"
-                        :key="filterLeague.id"
-                        small
-                        :ripple="false"
-                        outlined
-                        @click="pushLeague(filterLeague)"
-                      >
-                        {{ filterLeague.name }}
-                      </v-chip>
-                    </v-chip-group>
-                  </v-card-text>
-                </v-card>
-              </v-menu>
-              <v-card-text class="py-0">
-                <v-divider />
-              </v-card-text>
-              <v-card-text class="pt-2">
-                <v-chip-group
-                  column
-                >
-                  <v-chip
-                    v-for="category in league.categories"
-                    :key="category.id"
-                    small
-                    :ripple="false"
-                    outlined
-                  >
-                    {{ category.name }}
-                  </v-chip>
-                </v-chip-group>
-              </v-card-text>
-            </v-card>
-            <v-card
-              color="#f1f4f8"
-              width="300"
-              class="mt-8"
-              outlined
-            >
-              <v-card-text>
-                <v-icon color="primary">
-                  mdi-soccer-field
-                </v-icon>
-                <span
-                  class="font-weight-bold black--text"
-                  style="position: relative; top: 2px;"
-                >
-                  ポジション
-                </span>
-              </v-card-text>
-            </v-card>
-            <v-select
-              v-model="position"
-              class="mt-5"
-              background-color="white"
-              outlined
-              dense
-              :items="positions"
-              item-text="name"
-              return-object
-              style="max-width: 300px;"
-            />
-            <v-card
-              color="#f1f4f8"
-              width="300"
-              class="mt-2"
-              outlined
-            >
-              <v-card-text>
-                <v-icon color="primary">
-                  mdi-soccer
-                </v-icon>
-                <span
-                  class="font-weight-bold black--text"
-                  style="position: relative; top: 1px;"
-                >
-                  チーム
-                </span>
-              </v-card-text>
-            </v-card>
-            <v-select
-              class="mt-5"
-              background-color="white"
-              outlined
-              dense
-              no-data-text="選択できるチームがありません"
-              style="max-width: 300px;"
-            />
-            <v-btn
-              width="300"
-              large
-              :ripple="false"
-              color="#3949AB"
-              dark
-              class="font-weight-bold mt-3"
-            >
-              検索する
-            </v-btn>
-          </v-col>
-          <v-col
-            cols="12"
-            lg="8"
-          >
-            <div
-              class="font-weight-bold"
-              style="font-size: 1.8rem"
-            >
-              {{ league.name }}
-            </div>
-            <div v-if="$vuetify.breakpoint.mobile">
-              詳細条件
-            </div>
-            <v-tabs
-              class="mt-2"
-              background-color="#FAFAFA"
-              color="black"
-            >
-              <v-tab
-                class="font-weight-bold"
-                :ripple="false"
-              >
-                選手一覧
-              </v-tab>
-              <v-tab
-                class="font-weight-bold"
-                :ripple="false"
-              >
-                ランキング
-              </v-tab>
-            </v-tabs>
-            <v-divider />
-            <v-list
-              three-line
-              class="mt-5"
-              color="#FAFAFA"
-            >
-              <template v-for="(player, index) in players">
-                <v-list-item
-                  :key="player.id"
-                  class="pl-0"
-                  inactive
-                  :ripple="false"
-                  style="cursor: pointer;"
-                  @click="pushUserPage(player)"
-                >
-                  <v-avatar
-                    size="130"
-                    rounded=""
-                  >
-                    <v-img
-                      :src="player.avatar"
-                    />
-                  </v-avatar>
-                  <v-list-item-content class="ml-5">
-                    <v-list-item-title class="font-weight-bold text-h5 mt-2">
-                      {{ fullName(player) }}
-                    </v-list-item-title>
-                    <v-list-item-subtitle
-                      class="mt-2"
-                      style="margin-left: 1px;"
-                    >
-                      {{ information(player) }}
-                    </v-list-item-subtitle>
-                    <v-card-actions class="pl-0">
-                      <v-rating
-                        :value="3"
-                        background-color="#ef5350"
-                        color="#ef5350"
-                        readonly
-                        size="30"
-                        dense
-                        style="position: relative; right: 3px;"
-                      />
-                      <span class="ml-1 text-h5 font-weight-bold">
-                        3.0
-                      </span>
-                    </v-card-actions>
-                  </v-list-item-content>
-                </v-list-item>
-                <v-divider
-                  :key="index"
-                  class="my-5"
-                />
-              </template>
-            </v-list>
-          </v-col>
-        </v-row>
-      </v-container>
-    </div>
+    <v-container>
+      <v-row>
+        <player-search
+          :league="league"
+          :leagues="leagues"
+          :teams="teams"
+        />
+        <player-list
+          :users="users"
+          :league="league"
+        />
+      </v-row>
+    </v-container>
   </div>
 </template>
 
@@ -259,6 +26,8 @@
 import { mapGetters } from 'vuex'
 import Transform from "../../packs/league-transform"
 import TheBreadCrumb from "../globals/TheBreadCrumb"
+import PlayerSearch from "../parts/PlayerSearch"
+import PlayerList from "../parts/PlayerList"
 
 export default {
   components: {

--- a/app/javascript/components/pages/Player.vue
+++ b/app/javascript/components/pages/Player.vue
@@ -42,17 +42,17 @@ export default {
           },
           {
             text: this.user.profile.league.name,
-            to: `/${this.$route.params.league}`,
+            to: `/${Transform.leagueNameEigo(this.user.profile.league.name)}`,
             disabled: false
           },
           {
             text: this.user.profile.category.name,
-            to: `/${this.$route.params.league}/${this.$route.params.categoryId}`,
+            to: `/${Transform.leagueNameEigo(this.user.profile.league.name)}/${this.user.profile.category.id}`,
             disabled: false
           },
           {
             text: this.user.profile.group,
-            to: `/${this.$route.params.league}/${this.$route.params.categoryId}/${this.$route.params.groupId}`,
+            to: `/${Transform.leagueNameEigo(this.user.profile.league.name)}/${this.user.profile.category.id}/${this.user.profile.groupId}`,
             disabled: false
           },
           {
@@ -70,12 +70,12 @@ export default {
           },
           {
             text: this.user.profile.league.name,
-            to: `/${this.$route.params.league}`,
+            to: `/${Transform.leagueNameEigo(this.user.profile.league.name)}`,
             disabled: false
           },
           {
             text: this.user.profile.category.name,
-            to: `/${this.$route.params.league}/${this.$route.params.categoryId}`,
+            to: `/${Transform.leagueNameEigo(this.user.profile.league.name)}/${this.user.profile.category.id}`,
             disabled: false
           },
           {

--- a/app/javascript/components/pages/Player.vue
+++ b/app/javascript/components/pages/Player.vue
@@ -91,7 +91,7 @@ export default {
     }
   },
   created() {
-    this.getUser(this.$route.params.userId)
+    this.getUser()
   },
   methods: {
     async getUser(userId) {

--- a/app/javascript/components/pages/Player.vue
+++ b/app/javascript/components/pages/Player.vue
@@ -94,10 +94,11 @@ export default {
     this.getUser()
   },
   methods: {
-    async getUser(userId) {
+    async getUser() {
       this.loading = false
+      const userId = this.$route.params.userId
       const leagueId = Transform.getLeagueId(this.$route.params.league)
-      const response = await this.$axios.get(`/api/v1/${leagueId}/${this.$route.params.categoryId}/${this.$route.params.groupId}/users/${userId}`)
+      const response = await this.$axios.get(`/api/v1/users/${userId}?role=player`)
       this.user = response.data.user
       this.loading = true
     },

--- a/app/javascript/components/pages/Reviewer.vue
+++ b/app/javascript/components/pages/Reviewer.vue
@@ -55,7 +55,7 @@ export default {
   methods: {
     async getUser(userId) {
       this.loading = false
-      const response = await this.$axios.get(`/api/v1/users/${userId}`)
+      const response = await this.$axios.get(`/api/v1/users/${userId}?role=reviewer`)
       this.user = response.data.user
       this.loading = true
     },

--- a/app/javascript/components/parts/PlayerList.vue
+++ b/app/javascript/components/parts/PlayerList.vue
@@ -1,0 +1,80 @@
+<template>
+  <v-col
+    cols="12"
+    lg="8"
+  >
+    <div
+      class="font-weight-bold"
+      style="font-size: 1.8rem"
+    >
+      {{ league.name }}
+    </div>
+    <div v-if="$vuetify.breakpoint.mobile">
+      詳細条件
+    </div>
+    <v-tabs
+      class="mt-2"
+      background-color="#FAFAFA"
+      color="black"
+    >
+      <v-tab
+        class="font-weight-bold"
+        :ripple="false"
+      >
+        選手一覧
+      </v-tab>
+      <v-tab
+        class="font-weight-bold"
+        :ripple="false"
+      >
+        ランキング
+      </v-tab>
+    </v-tabs>
+    <v-divider />
+    <v-list
+      three-line
+      class="mt-2"
+      color="#FAFAFA"
+    >
+      <player-list-item
+        v-for="user in users"
+        :key="user.id"
+        :user="user"
+      />
+    </v-list>
+  </v-col>
+</template>
+
+<script>
+import PlayerListItem from "../parts/PlayerListItem.vue"
+
+export default {
+  components: {
+    PlayerListItem
+  },
+  props: {
+    league: {
+      type: Object,
+      default: () => {},
+      required: true
+    },
+    users: {
+      type: Array,
+      default: () => {},
+      required: true
+    }
+  },
+  methods: {
+    pushUserPage(user) {
+      if (this.currentUser.id === user.id) {
+        this.$router.push({ name: "profile" })
+      } else {
+        this.$router.push({
+          name: "playerProfile",
+          params: { league: this.$route.params.league, categoryId: user.profile.category.id, groupId: user.profile.groupId, userId: user.id }
+        })
+      }
+    },
+  }
+}
+</script>

--- a/app/javascript/components/parts/PlayerListItem.vue
+++ b/app/javascript/components/parts/PlayerListItem.vue
@@ -1,0 +1,86 @@
+<template>
+  <div>
+    <v-list-item
+      :key="user.id"
+      class="pl-0"
+      inactive
+      :ripple="false"
+      style="cursor: pointer;"
+      @click="pushUserPage"
+    >
+      <v-avatar
+        size="130"
+        rounded
+      >
+        <v-img
+          :src="user.avatar"
+        />
+      </v-avatar>
+      <v-list-item-content class="ml-5">
+        <v-list-item-title class="font-weight-bold text-h5 mt-2">
+          {{ fullName }}
+        </v-list-item-title>
+        <v-list-item-subtitle
+          class="mt-2"
+          style="margin-left: 1px;"
+        >
+          {{ information }}
+        </v-list-item-subtitle>
+        <v-card-actions class="pl-0">
+          <v-rating
+            :value="3"
+            background-color="#ef5350"
+            color="#ef5350"
+            readonly
+            size="30"
+            dense
+            style="position: relative; right: 3px;"
+          />
+          <span class="ml-1 text-h5 font-weight-bold">
+            3.0
+          </span>
+        </v-card-actions>
+      </v-list-item-content>
+    </v-list-item>
+    <v-divider
+      class="my-4"
+    />
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import Transform from "../../packs/league-transform"
+
+export default {
+  props: {
+    user: {
+      type: Object,
+      default: () => {},
+      required: true
+    }
+  },
+  computed: {
+    ...mapGetters({ currentUser: "user/currentUser" }),
+    fullName() {
+      return `${this.user.lastName} ${this.user.firstName}`
+    },
+    information() {
+      return `${this.user.profile.team}(${this.user.profile.prefecture.name}) ${this.user.profile.position} / ${this.user.profile.officialNumber}`
+    }
+  },
+  methods: {
+    pushUserPage() {
+      const leagueEigo = Transform.leagueNameEigo(this.user.profile.league.name)
+      if (this.currentUser.id === this.user.id) {
+        this.$router.push({ name: "profile" })
+      } else {
+        this.$router.push({
+          name: "playerProfile",
+          params: { league: leagueEigo, categoryId: this.user.profile.category.id, groupId: this.user.profile.groupId, userId: this.user.id }
+        })
+      }
+    },
+  }
+}
+</script>

--- a/app/javascript/components/parts/PlayerSearch.vue
+++ b/app/javascript/components/parts/PlayerSearch.vue
@@ -1,0 +1,252 @@
+<template>
+  <v-col
+    v-if="!$vuetify.breakpoint.mobile"
+    cols="12"
+    lg="4"
+  >
+    <v-card
+      width="300"
+      outlined
+    >
+      <v-card-text class="mt-2">
+        <v-icon color="primary">
+          mdi-map-marker
+        </v-icon>
+        <span
+          class="font-weight-bold black--text"
+          style="position: relative; top: 2px;"
+        >
+          リーグから探す
+        </span>
+      </v-card-text>
+      <v-menu
+        v-model="menu"
+        :close-on-content-click="false"
+        :nudge-width="200"
+        offset-x
+      >
+        <template #activator="{ on, attrs }">
+          <v-card-actions
+            class="font-weight-bold text-subtitle-1 blue--text text--darken-2 py-0 ml-1 pl-4"
+            style="cursor: pointer;"
+            v-bind="attrs"
+            v-on="on"
+          >
+            {{ league.name }}
+            <v-spacer />
+            <v-icon>
+              mdi-chevron-right
+            </v-icon>
+          </v-card-actions>
+        </template>
+        <v-card
+          color="#FAFAFA"
+          max-width="500"
+        >
+          <v-card-text>
+            <v-chip-group
+              column
+            >
+              <v-chip
+                outlined
+                small
+              >
+                全国
+              </v-chip>
+              <v-chip
+                v-for="filterLeague in filterLeagues"
+                :key="filterLeague.id"
+                small
+                :ripple="false"
+                outlined
+                @click="pushLeague(filterLeague)"
+              >
+                {{ filterLeague.name }}
+              </v-chip>
+            </v-chip-group>
+          </v-card-text>
+        </v-card>
+      </v-menu>
+      <v-card-text class="py-0">
+        <v-divider />
+      </v-card-text>
+      <v-card-text class="pt-2">
+        <v-chip-group
+          column
+        >
+          <v-chip
+            v-for="child in leagueChild"
+            :key="child.id"
+            small
+            :ripple="false"
+            outlined
+            @click="pushChildPage(child)"
+          >
+            {{ child.name }}
+          </v-chip>
+        </v-chip-group>
+      </v-card-text>
+    </v-card>
+    <v-card
+      color="#f1f4f8"
+      width="300"
+      class="mt-8"
+      outlined
+    >
+      <v-card-text>
+        <v-icon color="primary">
+          mdi-soccer-field
+        </v-icon>
+        <span
+          class="font-weight-bold black--text"
+          style="position: relative; top: 2px;"
+        >
+          ポジション
+        </span>
+      </v-card-text>
+    </v-card>
+    <v-select
+      v-model="position"
+      class="mt-5"
+      background-color="white"
+      outlined
+      dense
+      :items="positions"
+      item-text="name"
+      item-value="value"
+      return-object
+      style="max-width: 300px;"
+    />
+    <v-card
+      color="#f1f4f8"
+      width="300"
+      class="mt-2"
+      outlined
+    >
+      <v-card-text>
+        <v-icon color="primary">
+          mdi-soccer
+        </v-icon>
+        <span
+          class="font-weight-bold black--text"
+          style="position: relative; top: 1px;"
+        >
+          チーム
+        </span>
+      </v-card-text>
+    </v-card>
+    <v-select
+      v-model="team"
+      class="mt-5"
+      background-color="white"
+      outlined
+      dense
+      :items="teams"
+      item-value="id"
+      return-object
+      item-text="name"
+      no-data-text="選択できるチームがありません"
+      style="max-width: 300px;"
+    />
+    <v-btn
+      width="300"
+      large
+      :ripple="false"
+      color="#3949AB"
+      dark
+      class="font-weight-bold mt-3"
+      @click="searchPlayer"
+    >
+      検索する
+    </v-btn>
+  </v-col>
+</template>
+
+<script>
+import Transform from "../../packs/league-transform"
+
+export default {
+  props: {
+    league: {
+      type: Object,
+      default: () => {},
+      required: true
+    },
+    teams: {
+      type: Array,
+      default: () => {},
+      required: true
+    },
+    leagues: {
+      type: Array,
+      default: () => {},
+      required: true
+    }
+  },
+  data() {
+    return {
+      menu: false,
+      position: 10,
+      team: 0,
+      positions: [
+        {
+          name: "指定なし",
+          value: 10
+        },
+        {
+          name: "GK",
+          value: 0
+        },
+        {
+          name: "DF",
+          value: 1
+        },
+        {
+          name: "MF",
+          value: 2
+        },
+        {
+          name: "FW",
+          value: 3
+        }
+      ]
+    }
+  },
+  computed: {
+    filterLeagues() {
+      return this.leagues.filter(league => {
+        return league.id !== this.league.id
+      })
+    },
+    leagueChild() {
+      if (!this.$route.params.categoryId && !this.$route.params.groupId) return this.league.categories
+      if (!this.$route.params.groupId && this.league.groups.length >= 2) {
+        return this.league.groups
+      }
+    },
+  },
+  methods: {
+    searchPlayer() {
+      this.$emit("search-player", this.position, this,team)
+    },
+    pushLeague(league) {
+      if (!this.$route.params.categoryId && !this.$route.params.groupId) {
+        const leagueEigo = Transform.leagueNameEigo(league.name)
+        this.$router.push({ name: "leaguePlayer", params: { league: leagueEigo } })
+      } else if (!this.$route.params.groupId) {
+        this.$router.push({ name: "categoryPlayer", params: { categoryId: league.id } })
+      } else {
+        this.$router.push({ name: "groupPlayer", params: { groupId: league.id } })
+      }
+      this.menu = false
+    },
+    pushChildPage(child) {
+       if (!this.$route.params.categoryId) {
+         this.$router.push({ name: "categoryPlayer", params: { categoryId: child.id } })
+       } else {
+         this.$router.push({ name: "groupPlayer", params: { groupId: child.id } })
+       }
+    }
+  }
+}
+</script>

--- a/app/javascript/components/parts/PlayerSearch.vue
+++ b/app/javascript/components/parts/PlayerSearch.vue
@@ -219,9 +219,12 @@ export default {
       })
     },
     leagueChild() {
-      if (!this.$route.params.categoryId && !this.$route.params.groupId) return this.league.categories
-      if (!this.$route.params.groupId && this.league.groups.length >= 2) {
+      if (!this.$route.params.categoryId && !this.$route.params.groupId) {
+        return this.league.categories
+      } else if (!this.$route.params.groupId && this.league.groups.length >= 2) {
         return this.league.groups
+      } else {
+        return false
       }
     },
   },


### PR DESCRIPTION
## やったこと
選手一覧をコンポーネントに分割
リーグ、カテゴリ、グループでそれぞれ必要なデータとロジックを作成
選手を取得するエンドポイントを修正

## やらないこと
特になし

## できるようになること（ユーザ目線）
リーグ、カテゴリ、グループで選手が表示されるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
想定通りに表示されることを確認
必要なデータが返ってくることを確認

## その他
特になし
