### PR TITLE
追加と修正 #12

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,7 +37,7 @@ Metrics/BlockLength:
 Metrics/AbcSize:
   Max: 25   #default 15
   Exclude:
-    - "app/serializers/*.rb"
+    - "app/forms/*.rb"
 
 # 一行の長さは１５０文字まで。 コメントは制限しない
 Metrics/LineLength:

--- a/app/controllers/api/v1/categories/teams_controller.rb
+++ b/app/controllers/api/v1/categories/teams_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Categories::TeamsController < ApplicationController
+  def index
+    teams = Team.joins(profiles: { group: :category }).merge(Category.where(id: params[:category_id]))
+    render json: teams
+  end
+end

--- a/app/controllers/api/v1/categories/users_controller.rb
+++ b/app/controllers/api/v1/categories/users_controller.rb
@@ -1,6 +1,0 @@
-class Api::V1::Categories::UsersController < Api::V1::BaseController
-  def index
-    users = User.cache_profile.joins(profile: { group: :category }).merge(Category.where(id: params[:category_id]))
-    render json: users
-  end
-end

--- a/app/controllers/api/v1/groups/teams_controller.rb
+++ b/app/controllers/api/v1/groups/teams_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Groups::TeamsController < ApplicationController
+  def index
+    teams = Team.joins(profiles: :group).merge(Group.where(id: params[:group_id]))
+    render json: teams
+  end
+end

--- a/app/controllers/api/v1/groups/users_controller.rb
+++ b/app/controllers/api/v1/groups/users_controller.rb
@@ -1,6 +1,0 @@
-class Api::V1::Groups::UsersController < Api::V1::BaseController
-  def index
-    users = User.cache_profile.joins(profile: :group).merge(Group.where(id: params[:group_id]))
-    render json: users
-  end
-end

--- a/app/controllers/api/v1/leagues/teams_controller.rb
+++ b/app/controllers/api/v1/leagues/teams_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Leagues::TeamsController < ApplicationController
+  def index
+    teams = Team.joins(profiles: { group: { category: :league } }).merge(League.where(id: params[:league_id]))
+    render json: teams
+  end
+end

--- a/app/controllers/api/v1/leagues/users_controller.rb
+++ b/app/controllers/api/v1/leagues/users_controller.rb
@@ -1,6 +1,0 @@
-class Api::V1::Leagues::UsersController < Api::V1::BaseController
-  def index
-    users = User.cache_profile.joins(profile: { group: { category: :league } }).merge(League.where(id: params[:league_id]))
-    render json: users
-  end
-end

--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::PlayersController < ApplicationController
+  def index
+    search_users_form = SearchUsersForm.new(search_params)
+    users = search_users_form.search
+    render json: users
+  end
+
+  private
+
+  def search_params
+    params[:q]&.permit(:league_id, :category_id, :group_id, :position, :team_id)
+  end
+end

--- a/app/forms/search_users_form.rb
+++ b/app/forms/search_users_form.rb
@@ -11,9 +11,9 @@ class SearchUsersForm
   def search
     relation = User.cache_profile
 
-    relation = relation.joins(profile: { group: { category: :league } }).merge(League.where(id: league_id )) if league_id.present?
-    relation = relation.joins(profile: { group: :category }).merge(Category.where(id: category_id )) if category_id.present?
-    relation = relation.joins(profile: :group).merge(Group.where(id: group_id )) if group_id.present?
+    relation = relation.joins(profile: { group: { category: :league } }).merge(League.where(id: league_id)) if league_id.present?
+    relation = relation.joins(profile: { group: :category }).merge(Category.where(id: category_id)) if category_id.present?
+    relation = relation.joins(profile: :group).merge(Group.where(id: group_id)) if group_id.present?
 
     relation = relation.merge(Profile.where(position: position)) if position.present?
     relation = relation.merge(Profile.where(team_id: team_id)) if team_id.present?

--- a/app/forms/search_users_form.rb
+++ b/app/forms/search_users_form.rb
@@ -1,0 +1,23 @@
+class SearchUsersForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :league_id, :integer
+  attribute :category_id, :integer
+  attribute :group_id, :integer
+  attribute :position, :string
+  attribute :team_id, :integer
+
+  def search
+    relation = User.cache_profile
+
+    relation = relation.joins(profile: { group: { category: :league } }).merge(League.where(id: league_id )) if league_id.present?
+    relation = relation.joins(profile: { group: :category }).merge(Category.where(id: category_id )) if category_id.present?
+    relation = relation.joins(profile: :group).merge(Group.where(id: group_id )) if group_id.present?
+
+    relation = relation.merge(Profile.where(position: position)) if position.present?
+    relation = relation.merge(Profile.where(team_id: team_id)) if team_id.present?
+
+    relation
+  end
+end

--- a/app/javascript/plugins/axios.js
+++ b/app/javascript/plugins/axios.js
@@ -1,7 +1,12 @@
 import Axios from "axios"
 import store from "../store"
+import qs from 'qs'
 
-const instance = Axios.create()
+const instance = Axios.create({
+  paramsSerializer: (params) => {
+    return qs.stringify(params, {arrayFormat: 'brackets'})
+  }
+})
 
 instance.interceptors.request.use(request => {
   const csrfToken = document.getElementsByName("csrf-token")[0].content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
           end
         end
       end
-      resources :players, only: %i[index show]
+      resources :players, only: %i[index]
       resources :password_resets, only: %i[create edit update]
       resources :reviews, only: %i[index]
       resources :leagues, only: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,25 +28,23 @@ Rails.application.routes.draw do
           end
         end
       end
+      resources :players, only: %i[index show]
       resources :password_resets, only: %i[create edit update]
       resources :reviews, only: %i[index]
       resources :leagues, only: %i[index show] do
         resources :categories, only: %i[index]
         scope module: :leagues do
-          resources :users, only: %i[index]
           resources :teams, only: %i[index]
         end
       end
       resources :categories, only: %i[show] do
         resources :groups, only: %i[index]
         scope module: :categories do
-          resources :users, only: %i[index]
           resources :teams, only: %i[index]
         end
       end
       resources :groups, only: %i[show] do
         scope module: :groups do
-          resources :users, only: %i[index]
           resources :teams, only: %i[index]
         end
       end

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.3.0",
     "axios": "^0.21.1",
+    "qs": "^6.10.1",
     "turbolinks": "^5.2.0",
     "vee-validate": "^3.4.5",
     "vue": "^2.6.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5853,6 +5853,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
+
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
@@ -6365,6 +6372,15 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
## やったこと
各リーグ、カテゴリ、グループにチームを返すためのコントローラーと追加
検索機能の追加
選手を返すためにplayers_controllerを作成
ネストしたパラメータを送れるようにqsを追加
検索機能のためにforms/*.rbを作成

## やらないこと
全国の実装

## できるようになること（ユーザ目線）
リーグ、カテゴリ、グループ、ポジション、チームで検索をかけることができる

## できなくなること（ユーザ目線）
特になし

## 動作確認
検索できることを確認
ネストしたパラメーターを送れることを確認

## その他
ネストしたパラメーター参考
https://qiita.com/t1732/items/460b4aa2a830da6245eb

