### PR TITLE
追加と修正 #12

### DIFF
--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -8,6 +8,6 @@ class Api::V1::PlayersController < ApplicationController
   private
 
   def search_params
-    params[:q]&.permit(:league_id, :category_id, :group_id, :position, :team_id)
+    params[:q]&.permit(:league_id, :category_id, :group_id, :position, :team_id, :rating)
   end
 end

--- a/app/forms/search_users_form.rb
+++ b/app/forms/search_users_form.rb
@@ -7,6 +7,7 @@ class SearchUsersForm
   attribute :group_id, :integer
   attribute :position, :string
   attribute :team_id, :integer
+  attribute :rating, :boolean
 
   def search
     relation = User.cache_profile.joins(:profile)
@@ -14,9 +15,9 @@ class SearchUsersForm
     relation = relation.joins(profile: { group: { category: :league } }).merge(League.where(id: league_id)) if league_id.present?
     relation = relation.joins(profile: { group: :category }).merge(Category.where(id: category_id)) if category_id.present?
     relation = relation.joins(profile: :group).merge(Group.where(id: group_id)) if group_id.present?
-
     relation = relation.merge(Profile.where(position: position)) if position.present?
     relation = relation.merge(Profile.where(team_id: team_id)) if team_id.present?
+    relation = relation.order(rate: :desc) if rating
 
     relation
   end

--- a/app/javascript/components/pages/CategoryPlayer.vue
+++ b/app/javascript/components/pages/CategoryPlayer.vue
@@ -90,6 +90,9 @@ export default {
     }
   },
   computed: {
+    isRating() {
+      return this.$route.path.includes("ratings")
+    },
     breadCrumbs() {
       return [
         {

--- a/app/javascript/components/pages/CategoryPlayer.vue
+++ b/app/javascript/components/pages/CategoryPlayer.vue
@@ -126,24 +126,17 @@ export default {
       this.loading = true
     },
     async getPlayers() {
-      const response = await this.$axios.get(`/api/v1/players`, {
-        params: {
-          q: {
-            group_id: this.$route.params.categoryId
-          }
-        }
+      const q = { category_id: this.category.id }
+      this.isRating ? q.rating = true : q.rating = false
+      const response = await this.$axios.get("/api/v1/players", {
+        params: { q }
       })
       this.users = response.data.users
     },
-    async searchPlayer(position, team) {
+    async searchPlayer(q) {
+      q.category_id = this.$route.params.categoryId
       const response = await this.$axios.get(`/api/v1/players`, {
-        params: {
-          q: {
-            category_id: this.$route.params.categoryId,
-            position: position,
-            team_id: team
-          }
-        }
+        params: { q }
       })
       this.users = response.data.users
     },

--- a/app/javascript/components/pages/CategoryPlayer.vue
+++ b/app/javascript/components/pages/CategoryPlayer.vue
@@ -118,6 +118,7 @@ export default {
   },
   methods: {
     async getData() {
+      this.loading = false
       await this.getCategory()
       await this.getPlayers()
       await this.getCategories()

--- a/app/javascript/components/pages/CategoryPlayer.vue
+++ b/app/javascript/components/pages/CategoryPlayer.vue
@@ -74,8 +74,11 @@ export default {
   },
   beforeRouteUpdate(to, from, next) {
     next()
-    this.getCategory()
-    this.getPlayers()
+    if (to.params.categoryId !== from.params.categoryId) {
+      this.getData()
+    } else {
+      this.getPlayers()
+    }
   },
   data() {
     return {

--- a/app/javascript/components/pages/CategoryPlayer.vue
+++ b/app/javascript/components/pages/CategoryPlayer.vue
@@ -14,10 +14,47 @@
           :teams="teams"
           @search-player="searchPlayer"
         />
-        <player-list
-          :users="users"
-          :league="category"
-        />
+        <v-col
+          cols="12"
+          lg="8"
+        >
+          <div
+            class="font-weight-bold"
+            style="font-size: 1.8rem"
+          >
+            {{ category.name }}
+          </div>
+          <div v-if="$vuetify.breakpoint.mobile">
+            詳細条件
+          </div>
+          <v-tabs
+            class="mt-2"
+            background-color="#FAFAFA"
+            color="black"
+          >
+            <v-tab
+              exact
+              class="font-weight-bold"
+              :ripple="false"
+              :to="{ name: 'categoryPlayer' }"
+            >
+              選手一覧
+            </v-tab>
+            <v-tab
+              exact
+              class="font-weight-bold"
+              :ripple="false"
+              :to="{ name: 'categoryRating' }"
+            >
+              ランキング
+            </v-tab>
+          </v-tabs>
+          <v-divider />
+          <router-view
+            :users="users"
+            :league="category"
+          />
+        </v-col>
       </v-row>
     </v-container>
   </div>

--- a/app/javascript/components/pages/CategoryPlayer.vue
+++ b/app/javascript/components/pages/CategoryPlayer.vue
@@ -64,13 +64,11 @@
 import Transform from "../../packs/league-transform"
 import TheBreadCrumb from "../globals/TheBreadCrumb"
 import PlayerSearch from "../parts/PlayerSearch"
-import PlayerList from "../parts/PlayerList"
 
 export default {
   components: {
     TheBreadCrumb,
     PlayerSearch,
-    PlayerList
   },
   beforeRouteUpdate(to, from, next) {
     next()

--- a/app/javascript/components/parts/PlayerSearch.vue
+++ b/app/javascript/components/parts/PlayerSearch.vue
@@ -48,10 +48,10 @@
               column
             >
               <v-chip
+                v-if="!isWhole"
                 outlined
                 small
                 to="/whole"
-                v-if="!isWhole"
               >
                 全国
               </v-chip>

--- a/app/javascript/components/parts/ProfileTitle.vue
+++ b/app/javascript/components/parts/ProfileTitle.vue
@@ -8,7 +8,7 @@
     </v-list-item-title>
     <v-list-item-title>
       <v-rating
-        v-model="rating"
+        :value="+user.profile.rate"
         background-color="#EF5350"
         color="#EF5350"
         class="mr-1 float-left"
@@ -20,7 +20,7 @@
         class="text-h5 font-weight-bold"
         style="position: relative; bottom: 2px;"
       >
-        {{ rating }}
+        {{ user.profile.rate }}
       </span>
     </v-list-item-title>
   </div>
@@ -33,11 +33,6 @@ export default {
       type: Object,
       default: () => {},
       required: true
-    }
-  },
-  data() {
-    return {
-      rating: 3.1
     }
   },
   computed: {

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -13,6 +13,7 @@ import LeaguePlayer from "../components/pages/LeaguePlayer"
 import CategoryPlayer from "../components/pages/CategoryPlayer"
 import GroupPlayer from "../components/pages/GroupPlayer"
 import NotFound from "../components/pages/NotFound"
+import PlayerList from "../components/parts/PlayerList"
 
 const routes = [
   {
@@ -54,23 +55,67 @@ const routes = [
   },
   {
     path: "/whole",
-    name: "wholePlayer",
-    component: WholePlayer
+    component: WholePlayer,
+    children: [
+      {
+        path: "",
+        name: "wholePlayer",
+        component: PlayerList
+      },
+      {
+        path: "ratings",
+        name: "wholeRating",
+        component: PlayerList
+      }
+    ]
   },
   {
     path: "/:league",
-    name: "leaguePlayer",
-    component: LeaguePlayer
+    component: LeaguePlayer,
+    children: [
+      {
+        path: "",
+        name: "leaguePlayer",
+        component: PlayerList
+      },
+      {
+        path: "ratings",
+        name: "leagueRating",
+        component: PlayerList
+      }
+    ]
   },
   {
     path: "/:league/:categoryId",
-    name: "categoryPlayer",
-    component: CategoryPlayer
+    component: CategoryPlayer,
+    children: [
+      {
+        path: "",
+        name: "categoryPlayer",
+        component: PlayerList
+      },
+      {
+        path: "ratings",
+        name: "categoryRating",
+        component: PlayerList
+      }
+    ]
   },
   {
     path: "/:league/:categoryId/:groupId",
-    name: "groupPlayer",
-    component: GroupPlayer
+    component: GroupPlayer,
+    children: [
+      {
+        path: "",
+        name: "groupPlayer",
+        component: PlayerList
+      },
+      {
+        path: "ratings",
+        name: "groupRating",
+        component: PlayerList
+      }
+    ]
   },
   {
     name: "notFound",


### PR DESCRIPTION
## やったこと
ロジックの追加
ランキングを選んだときにレート順に並び替えられるように追加
リーグ名とタブの部分はコンポーネントだと扱いにくいためルートで表示

## やらないこと
特になし

## できるようになること（ユーザ目線）
ランキングを選択するとレート順で表示されるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
ランキング選択時にレート順で表示されることを確認

## その他
特になし
