### PR TITLE
追加と修正 #12

### DIFF
--- a/app/javascript/components/globals/TheHeader.vue
+++ b/app/javascript/components/globals/TheHeader.vue
@@ -76,7 +76,7 @@
                 large
                 :ripple="false"
                 class="justify-start"
-                @click="pushPage('/profile', 'profile')"
+                @click="pushPage('/profile', 'myReview')"
               >
                 <v-avatar
                   style="position: relative; right: 5px;"

--- a/app/javascript/components/parts/HomeReviews.vue
+++ b/app/javascript/components/parts/HomeReviews.vue
@@ -133,15 +133,15 @@ export default {
   },
   methods: {
     pushUserPage(user) {
-      if (this.currentUser.id === user.id) return this.$router.push({ name: "profile" })
+      if (this.currentUser.id === user.id) return this.$router.push({ name: "myReview" })
       if (user.role === "player") {
         const leagueEigo = Transform.leagueNameEigo(user.profile.league.name)
         this.$router.push({
-          name: "playerProfile",
+          name: "playerReview",
           params: { league: leagueEigo, categoryId: user.profile.category.id, groupId: user.profile.groupId, userId: user.id }
         })
       } else {
-        this.$router.push({ name: "reviewerProfile", params: { userId: user.id } })
+        this.$router.push({ name: "reviewerReview", params: { userId: user.id } })
       }
     }
   }

--- a/app/javascript/components/parts/PlayerListItem.vue
+++ b/app/javascript/components/parts/PlayerListItem.vue
@@ -77,10 +77,10 @@ export default {
     pushUserPage() {
       const leagueEigo = Transform.leagueNameEigo(this.user.profile.league.name)
       if (this.currentUser.id === this.user.id) {
-        this.$router.push({ name: "profile" })
+        this.$router.push({ name: "myReview" })
       } else {
         this.$router.push({
-          name: "playerProfile",
+          name: "playerReview",
           params: { league: leagueEigo, categoryId: this.user.profile.category.id, groupId: this.user.profile.groupId, userId: this.user.id }
         })
       }

--- a/app/javascript/components/parts/ProfileTab.vue
+++ b/app/javascript/components/parts/ProfileTab.vue
@@ -5,14 +5,28 @@
     :class="$vuetify.breakpoint.mobile ? 'px-4' : ''"
   >
     <v-tab
-      v-for="route in routes"
-      :key="route.name"
       exact
       :ripple="false"
       class="font-weight-bold"
-      :to="{ name: setName, params: { type: route.params } }"
+      :to="{ name: setReviewName }"
     >
-      {{ route.name }}
+      レビュー
+    </v-tab>
+    <v-tab
+      exact
+      :ripple="false"
+      class="font-weight-bold"
+      :to="{ name: setFollowingName }"
+    >
+      フォロー
+    </v-tab>
+    <v-tab
+      exact
+      :ripple="false"
+      class="font-weight-bold"
+      :to="{ name: setFollowersName }"
+    >
+      フォロワー
     </v-tab>
   </v-tabs>
 </template>
@@ -26,35 +40,34 @@ export default {
       required: true
     }
   },
-  data() {
-    return {
-      routes: [
-        {
-          name: "レビュー"
-        },
-        {
-          name: "フォロー",
-          params: "following"
-        },
-        {
-          name: "フォロワー",
-          params: "followers"
-        }
-      ]
-    }
-  },
   computed: {
-    setName() {
-      let name = ""
-      if (!this.$route.path.includes("/profile") && this.user.role === "player")  {
-        name = "playerProfile"
-      } else if (!this.$route.path.includes("/profile") && this.user.role === "reviewer") {
-        name = "reviewerProfile"
-      } else if (this.$route.path.includes("/profile")) {
-        name = "profile"
+    setReviewName() {
+      if (this.$route.path.includes("profile")) {
+        return "myReview"
+      } else if (this.$route.path.includes("users")) {
+        return "reviewerReview"
+      } else {
+        return "playerReview"
       }
-      return name
     },
+    setFollowingName() {
+      if (this.$route.path.includes("profile")) {
+        return "myFollowing"
+      } else if (this.$route.path.includes("users")) {
+        return "reviewerFollowing"
+      } else {
+        return "playerFollowing"
+      }
+    },
+    setFollowersName() {
+      if (this.$route.path.includes("profile")) {
+        return "myFollowers"
+      } else if (this.$route.path.includes("users")) {
+        return "reviewerFollowers"
+      } else {
+        return "playerFollowers"
+      }
+    }
   }
 }
 </script>

--- a/app/javascript/components/parts/RelationCardItem.vue
+++ b/app/javascript/components/parts/RelationCardItem.vue
@@ -88,15 +88,15 @@ export default {
       this.isFollow = !this.isFollow
     },
     pushUserPage(user) {
-      if (this.currentUser.id === user.id) return this.$router.push({ name: "profile" })
+      if (this.currentUser.id === user.id) return this.$router.push({ name: "myReview" })
       if (user.role === "player") {
         const leagueEigo = Transform.leagueNameEigo(user.profile.league.name)
         this.$router.push({
-          name: "playerProfile",
+          name: "playerReview",
           params: { league: leagueEigo, categoryId: user.profile.category.id, groupId: user.profile.groupId, userId: user.id }
         })
       } else {
-        this.$router.push({ name: "reviewerProfile", params: { userId: user.id } })
+        this.$router.push({ name: "reviewerReview", params: { userId: user.id } })
       }
     },
     async checkFollow() {

--- a/app/javascript/components/parts/ReviewCard.vue
+++ b/app/javascript/components/parts/ReviewCard.vue
@@ -278,15 +278,15 @@ export default {
       }
     },
     pushUserPage() {
-      if (this.currentUser.id === this.reviewUser.id) return this.$router.push({ name: "profile" })
+      if (this.currentUser.id === this.reviewUser.id) return this.$router.push({ name: "myReview" })
       if (this.reviewUser.role === "player") {
         const leagueEigo = Transform.leagueNameEigo(this.reviewUser.profile.league.name)
         this.$router.push({
-          name: "playerProfile",
+          name: "playerReview",
           params: { league: leagueEigo, categoryId: this.reviewUser.profile.category.id, groupId: this.reviewUser.profile.groupId, userId: this.reviewUser.id }
         })
       } else {
-        this.$router.push({ name: "reviewerProfile", params: { userId: this.reviewUser.id } })
+        this.$router.push({ name: "reviewerReview", params: { userId: this.reviewUser.id } })
       }
     },
     async changePrivacy(setting) {

--- a/app/javascript/components/parts/TheProfileWrapper.vue
+++ b/app/javascript/components/parts/TheProfileWrapper.vue
@@ -185,11 +185,6 @@ export default {
     this.checkFollow()
     this.getReviews()
   },
-  mounted() {
-    if (!this.$route.params.type) return
-    if (this.$route.params.type.includes("following") || this.$route.params.type.includes("followers")) return
-    this.$store.dispatch("notFound/setNotFound", true)
-  },
   methods: {
     setFollowIds(id) {
       this.ids.push(id)

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -14,6 +14,8 @@ import CategoryPlayer from "../components/pages/CategoryPlayer"
 import GroupPlayer from "../components/pages/GroupPlayer"
 import NotFound from "../components/pages/NotFound"
 import PlayerList from "../components/parts/PlayerList"
+import ReviewCard from "../components/parts/ReviewCard"
+import RelationCard from "../components/parts/RelationCard"
 
 const routes = [
   {
@@ -27,10 +29,26 @@ const routes = [
     component: SignupLogin
   },
   {
-    path: "/profile/:type?",
-    name: "profile",
+    path: "/profile",
     component: Mypage,
     meta: { requiredLogin: true },
+    children: [
+      {
+        path: "",
+        name: "myReview",
+        component: ReviewCard
+      },
+      {
+        path: "following",
+        name: "myFollowing",
+        component: RelationCard
+      },
+      {
+        path: "followers",
+        name: "myFollowers",
+        component: RelationCard
+      }
+    ]
   },
   {
     path: "/settings/:type",
@@ -39,15 +57,27 @@ const routes = [
     meta: { requiredLogin: true }
   },
   {
-    path: "/users/:userId/:type?",
-    name: "reviewerProfile",
+    path: "/users/:userId",
     component: Reviewer,
+    children: [
+      {
+        path: "",
+        name: "reviewerReview",
+        component: ReviewCard
+      },
+      {
+        path: "following",
+        name: "reviewerFollowing",
+        component: RelationCard
+      },
+      {
+        path: "followers",
+        name: "reviewerFollowers",
+        component: RelationCard
+      }
+    ]
   },
-  {
-    path: "/:league/:categoryId/:groupId/:userId/:type?",
-    name: "playerProfile",
-    component: Player
-  },
+
   {
     path: "/account/:type",
     name: "passwordReset",
@@ -114,6 +144,27 @@ const routes = [
         path: "ratings",
         name: "groupRating",
         component: PlayerList
+      }
+    ]
+  },
+  {
+    path: "/:league/:categoryId/:groupId/:userId",
+    component: Player,
+    children: [
+      {
+        path: "",
+        name: "playerReview",
+        component: ReviewCard
+      },
+      {
+        path: "following",
+        name: "playerFollowing",
+        component: RelationCard
+      },
+      {
+        path: "followers",
+        name: "playerFollowers",
+        component: RelationCard
       }
     ]
   },


### PR DESCRIPTION
## やったこと
選手の詳細ページとリーグのレートで被ってしまいリロードをすると選手の詳細ページで読み込まれてしまうため、
選手の詳細ページよりもリーグのレートのパスを上に移動
詳細ページで特定のパスのみ受け付けるように修正


## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
following,followers以外のルートに遷移すると404

## 動作確認
特定のパスのみ受け付けることを確認
リーグのレートでリロードしても404が出ないことを確認

## その他
特になし
