### PR TITLE
バグの修正

### DIFF
--- a/app/javascript/components/parts/TheAreaChangeDialog.vue
+++ b/app/javascript/components/parts/TheAreaChangeDialog.vue
@@ -153,6 +153,11 @@ export default {
       return groups
     },
   },
+  watch: {
+    dialog() {
+      this.setId()
+    }
+  },
   async created() {
     await this.getLeagueData()
     await this.setId()
@@ -177,6 +182,8 @@ export default {
       this.dialog = true
     },
     close() {
+      this.league = ""
+      this.resetId()
       this.dialog = false
     },
     pushWhole() {

--- a/app/javascript/components/parts/ThePlayerSearchDialog.vue
+++ b/app/javascript/components/parts/ThePlayerSearchDialog.vue
@@ -42,13 +42,12 @@
               cols="12"
             >
               <v-select
-                :value="position"
+                v-model="positionData"
                 outlined
                 dense
                 :items="positions"
                 item-text="name"
                 item-value="value"
-                @change="$emit('update:position', $event)"
               />
             </v-col>
             <v-col
@@ -62,13 +61,12 @@
               cols="12"
             >
               <v-select
-                :value="teamId"
+                v-model="teamData"
                 outlined
                 dense
                 :items="teams"
                 item-value="id"
                 item-text="name"
-                @change="$emit('update:teamId', $event)"
               />
             </v-col>
             <v-col cols="12">
@@ -112,6 +110,8 @@ export default {
   data() {
     return {
       dialog: false,
+      teamData: this.teamId,
+      positionData: this.position,
       positions: [
         {
           name: "指定なし",
@@ -136,20 +136,29 @@ export default {
       ]
     }
   },
+  watch: {
+    $route() {
+      this.resetSearch()
+    }
+  },
   methods: {
     open() {
       this.dialog = true
     },
     close() {
+      this.teamData = this.teamId,
+      this.positionData = this.position,
       this.dialog = false
     },
     searchPlayer() {
+      this.$emit("update:teamId", this.teamData)
+      this.$emit("update:position", this.positionData)
       this.dialog = false
       this.$emit("search-player")
     },
     resetSearch() {
-      this.$emit("update:position", "")
-      this.$emit("update:teamId", "")
+      this.positionData = ""
+      this.teamData = ""
     },
   }
 }


### PR DESCRIPTION
## やったこと
モバイルでのエリア変更とフィルターのバグの修正
内容としてエリア変更ではモーダルをクローズした際にエリアを変更していないのにフォームに指定したエリアが残ってしまうバグの修正
フィルターでは選択した際に常にアップデートされてしまい、フィルターしていないのにフィルターの文字がでてしまっていたので、
propsを一度dataで扱うことに変更

## やらないこと
特になし

## できるようになること（ユーザ目線）
バグが発生しなくなる

## できなくなること（ユーザ目線）
特になし

## 動作確認
バグが発生しないことを確認

## その他
特になし
