### PR TITLE
追加と修正 #301

### DIFF
--- a/app/javascript/components/pages/Search.vue
+++ b/app/javascript/components/pages/Search.vue
@@ -229,6 +229,14 @@ export default {
       const unspecified = { name: "指定なし", id: "" }
       this.leagues.unshift(unspecified)
     },
+    setTeamUnspecified() {
+      const unspecified = { name: "指定なし", id: "" }
+      this.teams.unshift(unspecified)
+    },
+    checkQuery() {
+      if (this.q.team === "指定なし") this.q.team = undefined
+      if (this.q.position === "指定なし") this.q.position = undefined
+    },
     pushSearchPage() {
       if (!this.q.leagueId && !this.q.categoryId && !this.q.groupId) {
         this.$router.push({ name: 'wholePlayer', params: { q: this.q } })
@@ -245,6 +253,10 @@ export default {
         const leagueEigo = this.leagueNameEigo(league)
         this.$router.push({ name: "groupPlayer", params: { league: leagueEigo, categoryId: this.q.categoryId, groupId: this.q.groupId, search: this.q } })
       }
+    },
+    async getTeams() {
+      const response = await this.$axios.get("/api/v1/teams")
+      this.teams = response.data.teams
     },
     async getLeagueData() {
       const response = await this.$axios.get("/api/v1/hierarchy_leagues")

--- a/app/javascript/components/pages/Search.vue
+++ b/app/javascript/components/pages/Search.vue
@@ -220,12 +220,17 @@ export default {
       return groups
     },
   },
-  async created() {
-    await this.getLeagueData()
-    await this.setLeagueData()
-    this.loading = true
+  created() {
+    this.setData()
   },
   methods: {
+    async setData() {
+      await this.getLeagueData()
+      await this.setLeagueUnspecified()
+      await this.getTeams()
+      await this.setTeamUnspecified()
+      this.loading = true
+    },
     resetId() {
       this.q.groupId = ""
       this.q.categoryId = ""

--- a/app/javascript/components/pages/Search.vue
+++ b/app/javascript/components/pages/Search.vue
@@ -238,20 +238,24 @@ export default {
       if (this.q.position === "指定なし") this.q.position = undefined
     },
     pushSearchPage() {
+      this.checkQuery()
+      const query = { team: this.q.team, position: this.q.position }
+      if (!!this.q.team) return this.$router.push({ name: "wholePlayer", query: query })
+      delete query.team
       if (!this.q.leagueId && !this.q.categoryId && !this.q.groupId) {
-        this.$router.push({ name: 'wholePlayer', params: { q: this.q } })
+        this.$router.push({ name: "wholePlayer", query: query })
       } else if (this.q.leagueId && !this.q.categoryId && !this.q.groupId) {
         const league = this.leagues.find(league => league.id === this.q.leagueId)
         const leagueEigo = this.leagueNameEigo(league.name)
-        this.$router.push({ name: "leaguePlayer", params: { league: leagueEigo, search: this.q } })
+        this.$router.push({ name: "leaguePlayer", params: { league: leagueEigo }, query: query })
       } else if (this.q.leagueId && this.q.categoryId && !this.q.groupId) {
         const league = this.leagues.find(league => league.id === this.q.leagueId).name
         const leagueEigo = this.leagueNameEigo(league)
-        this.$router.push({ name: "categoryPlayer", params: { league: leagueEigo, categoryId: this.q.categoryId, search: this.q } })
+        this.$router.push({ name: "categoryPlayer", params: { league: leagueEigo, categoryId: this.q.categoryId }, query: query })
       } else {
         const league = this.leagues.find(league => league.id === this.q.leagueId).name
         const leagueEigo = this.leagueNameEigo(league)
-        this.$router.push({ name: "groupPlayer", params: { league: leagueEigo, categoryId: this.q.categoryId, groupId: this.q.groupId, search: this.q } })
+        this.$router.push({ name: "groupPlayer", params: { league: leagueEigo, categoryId: this.q.categoryId, groupId: this.q.groupId }, query: query })
       }
     },
     async getTeams() {

--- a/app/javascript/components/pages/Search.vue
+++ b/app/javascript/components/pages/Search.vue
@@ -121,9 +121,15 @@
                     class="py-0"
                     cols="12"
                   >
-                    <v-select
+                    <v-autocomplete
+                      v-model="q.team"
                       outlined
                       dense
+                      :items="teams"
+                      item-text="name"
+                      item-value="name"
+                      persistent-hint
+                      hint="※ チームを指定すると全国での表示になります"
                     />
                   </v-col>
                 </template>

--- a/app/javascript/components/pages/Search.vue
+++ b/app/javascript/components/pages/Search.vue
@@ -225,7 +225,7 @@ export default {
       this.q.groupId = ""
       this.q.categoryId = ""
     },
-    setLeagueData() {
+    setLeagueUnspecified() {
       const unspecified = { name: "指定なし", id: "" }
       this.leagues.unshift(unspecified)
     },

--- a/app/javascript/components/pages/Search.vue
+++ b/app/javascript/components/pages/Search.vue
@@ -165,34 +165,30 @@ export default {
       dialog: false,
       deepSearch: false,
       leagues: [],
+      teams: [],
       q: {
         leagueId: "",
         categoryId: "",
         groupId: "",
-        position: "",
-        teamId: ""
+        position: "指定なし",
+        team: "指定なし"
       },
       loading: false,
       positions: [
         {
           name: "指定なし",
-          value: ""
         },
         {
           name: "GK",
-          value: 0
         },
         {
           name: "DF",
-          value: 1
         },
         {
           name: "MF",
-          value: 2
         },
         {
           name: "FW",
-          value: 3
         }
       ]
     }

--- a/app/javascript/components/pages/Search.vue
+++ b/app/javascript/components/pages/Search.vue
@@ -175,21 +175,11 @@ export default {
       },
       loading: false,
       positions: [
-        {
-          name: "指定なし",
-        },
-        {
-          name: "GK",
-        },
-        {
-          name: "DF",
-        },
-        {
-          name: "MF",
-        },
-        {
-          name: "FW",
-        }
+        { name: "指定なし"},
+        { name: "GK" },
+        { name: "DF" },
+        { name: "MF" },
+        { name: "FW" }
       ]
     }
   },

--- a/app/javascript/components/parts/PlayerList.vue
+++ b/app/javascript/components/parts/PlayerList.vue
@@ -203,11 +203,8 @@ export default {
       return [...Array(20)].map((_, i) => (this.currentPage - 1) * 20 + 1 + i * 1)
     }
   },
-  created() {
-    if (this.$route.path.includes("ratings")) {
-      this.$router.push({ name: "wholeRating", query: { page: this.page } }, () => {})
-      this.tab = 1
-    }
+  mounted() {
+    if (this.$route.path.includes("ratings")) this.tab = 1
   },
   methods: {
     pushPlayer() {

--- a/app/javascript/components/parts/PlayerList.vue
+++ b/app/javascript/components/parts/PlayerList.vue
@@ -209,28 +209,28 @@ export default {
   methods: {
     pushPlayer() {
       this.tab = 0
-      this.$emit("update:page", 1)
+      const query = { team: this.$route.query.team, position: this.$route.query.position, page: undefined }
       if (this.isWhole) {
-        return this.$router.push({ name: "wholePlayer" }, () => {})
+        return this.$router.push({ name: "wholePlayer", query: query }, () => {})
       } else if (!this.isWhole && !this.$route.params.categoryId && !this.$route.params.groupId) {
-        return this.$router.push({ name: "leaguePlayer" }, () => {})
+        return this.$router.push({ name: "leaguePlayer", query: query }, () => {})
       } else if (!this.isWhole && !this.$route.params.groupId) {
-        return this.$router.push({ name: "categoryPlayer" }, () => {})
+        return this.$router.push({ name: "categoryPlayer", query: query }, () => {})
       } else {
-        return this.$router.push({ name: "groupPlayer" }, () => {})
+        return this.$router.push({ name: "groupPlayer", query: query }, () => {})
       }
     },
     pushRating() {
       this.tab = 1
-      this.$emit("update:page", 1)
+      const query = { team: this.$route.query.team, position: this.$route.query.position, page: undefined }
       if (this.isWhole) {
-        return this.$router.push({ name: "wholeRating" }, () => {})
+        return this.$router.push({ name: "wholeRating", query: query }, () => {})
       } else if (!this.isWhole && !this.$route.params.categoryId && !this.$route.params.groupId) {
-        return this.$router.push({ name: "leagueRating" }, () => {})
+        return this.$router.push({ name: "leagueRating", query: query }, () => {})
       } else if (!this.isWhole && !this.$route.params.groupId) {
-        return this.$router.push({ name: "categoryRating" }, () => {})
+        return this.$router.push({ name: "categoryRating", query: query }, () => {})
       } else {
-        return this.$router.push({ name: "groupRating" }, () => {})
+        return this.$router.push({ name: "groupRating", query: query }, () => {})
       }
     },
     searchPlayer(q, data) {

--- a/app/javascript/components/parts/PlayerList.vue
+++ b/app/javascript/components/parts/PlayerList.vue
@@ -257,23 +257,8 @@ export default {
     },
     pagination(e) {
       this.$emit("update:page", e)
-      if (e === 1) {
-        this.$router.push({ name: this.$route.name }, () => {})
-        return this.$vuetify.goTo(0)
-      }
-      if (this.isWhole) {
-        this.$vuetify.goTo(0)
-        return this.$router.push({ name: this.$route.name, query: { page: e } }, () => {})
-      } else if (!this.isWhole && !this.$route.params.categoryId && !this.$route.params.groupId) {
-        this.$vuetify.goTo(0)
-        return this.$router.push({ name: this.$route.name, query: { page: e } }, () => {})
-      } else if (!this.isWhole && !this.$route.params.groupId) {
-        this.$vuetify.goTo(0)
-        return this.$router.push({ name: this.$route.name, query: { page: e } }, () => {})
-      } else {
-        this.$vuetify.goTo(0)
-        return this.$router.push({ name: this.$route.name, query: { page: e } }, () => {})
-      }
+      const query = { team: this.$route.query.team, position: this.$route.query.position, page: e }
+      this.$router.push({ name: this.$route.name, query: query }, () => {})
     }
   }
 }

--- a/app/javascript/components/parts/PlayerSearch.vue
+++ b/app/javascript/components/parts/PlayerSearch.vue
@@ -254,8 +254,12 @@ export default {
       this.$emit("update:teamId", "")
     },
     searchPlayer() {
-      this.$router.push({ name: this.$route.name }, () => {})
-      this.$emit("search-player")
+      delete this.$route.query.page
+      let team = this.teams.find(team => team.id === this.teamId)
+      if (team.name === "指定なし") team = ""
+      let position = this.positions.find(position => position.value === this.position)
+      if (position.name === "指定なし") position = ""
+      this.$router.push({ name: this.$route.name, query: { team: team.name, position: position.name, page: undefined } }, () => {})
     },
     pushLeague(league) {
       this.resetSearch()

--- a/app/javascript/components/parts/ProfileTable.vue
+++ b/app/javascript/components/parts/ProfileTable.vue
@@ -161,15 +161,6 @@ export default {
     },
     reviewCount() {
       return `${this.totalCount}件`
-    },
-    reviewAverage() {
-      if (this.reviews.length === 0) return 0
-      const rateArray = this.reviews.map(review => +review.rate)
-      const sumRate = rateArray.reduce((rate, currentRate) => {
-        return rate + currentRate
-      })
-      const rateAverage = sumRate / this.reviews.length
-      return Math.round(rateAverage * 10) / 10
     }
   },
 }

--- a/app/javascript/components/parts/ProfileTable.vue
+++ b/app/javascript/components/parts/ProfileTable.vue
@@ -95,6 +95,11 @@ export default {
       type: Number,
       default: 0,
       required: true
+    },
+    average: {
+      type: Number,
+      default: 0,
+      required: true
     }
   },
   computed: {
@@ -126,7 +131,7 @@ export default {
         },
         {
           name: "レビュー平均",
-          information: this.reviewAverage
+          information: this.average
         }
       ]
     },


### PR DESCRIPTION
## やったこと
ロジックの修正
チームのフォームをセレクトからオートコンプリートに修正
検索する際のロジックの修正
選手検索時のロジックの修正
選手一覧とランキングを切り替え時のロジックの修正
ページネーション時のロジックの修正

## やらないこと
特になし

## できるようになること（ユーザ目線）
チームからも検索できるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
チームのフォームをセレクトからオートコンプリートに修正したことで検索もできるようになったことを確認
チームを選択していた場合は全国での表示になることを確認
想定通りに表示されることを確認

## その他
特になし
