### PR TITLE
追加と修正 #8

### DIFF
--- a/app/controllers/api/v1/users/current/profiles_controller.rb
+++ b/app/controllers/api/v1/users/current/profiles_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Users::Current::ProfilesController < Api::V1::BaseController
   before_action :required_login, only: %i[create update destroy]
   before_action :check_activation, only: %i[create update destroy]
+  before_action :check_birthday, only: %i[create update]
   before_action :check_age, only: %i[create update]
 
   def create
@@ -34,11 +35,12 @@ class Api::V1::Users::Current::ProfilesController < Api::V1::BaseController
     params.require(:profile).permit(:position, :official_number, :practice_number, :career, :group_id, :team_id)
   end
 
+  def check_birthday
+    return render json: { message: '生年月日を登録してください' }, status: :bad_request unless current_user.birth_date.present?
+  end
+
   def check_age
-    if (!current_user.birth_date.present?)
-      return render json: { message: '生年月日を登録してください' }, status: :bad_request
-    end
-    today = if (Date.today.strftime('%m%d').to_i < '0402'.to_i)
+    today = if Date.today.strftime('%m%d').to_i < '0402'.to_i
               Date.today.ago(1.years)
             else
               Date.today
@@ -46,8 +48,6 @@ class Api::V1::Users::Current::ProfilesController < Api::V1::BaseController
     first = today.ago(15.years).strftime('%Y0401')
     third = today.ago(18.years).strftime('%Y0402')
     birth = current_user.birth_date.strftime('%Y%m%d')
-    unless (birth.to_i >= third.to_i && birth.to_i <= first.to_i)
-      return render json: { message: '高校生のみ登録可能です' }, status: :bad_request
-    end
+    return render json: { message: '高校生のみ登録可能です' }, status: :bad_request unless birth.to_i >= third.to_i && birth.to_i <= first.to_i
   end
 end

--- a/app/controllers/api/v1/users/current/profiles_controller.rb
+++ b/app/controllers/api/v1/users/current/profiles_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Users::Current::ProfilesController < Api::V1::BaseController
   before_action :required_login, only: %i[create update destroy]
   before_action :check_activation, only: %i[create update destroy]
+  before_action :check_age, only: %i[create update]
 
   def create
     profile = current_user.build_profile(profile_params)
@@ -31,5 +32,22 @@ class Api::V1::Users::Current::ProfilesController < Api::V1::BaseController
 
   def profile_params
     params.require(:profile).permit(:position, :official_number, :practice_number, :career, :group_id, :team_id)
+  end
+
+  def check_age
+    if (!current_user.birth_date.present?)
+      return render json: { message: '生年月日を登録してください' }, status: :bad_request
+    end
+    today = if (Date.today.strftime('%m%d').to_i < '0402'.to_i)
+              Date.today.ago(1.years)
+            else
+              Date.today
+            end
+    first = today.ago(15.years).strftime('%Y0401')
+    third = today.ago(18.years).strftime('%Y0402')
+    birth = current_user.birth_date.strftime('%Y%m%d')
+    unless (birth.to_i >= third.to_i && birth.to_i <= first.to_i)
+      return render json: { message: '高校生のみ登録可能です' }, status: :bad_request
+    end
   end
 end

--- a/app/controllers/api/v1/users/currents_controller.rb
+++ b/app/controllers/api/v1/users/currents_controller.rb
@@ -24,6 +24,6 @@ class Api::V1::Users::CurrentsController < Api::V1::BaseController
   private
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :avatar, :email, :introduction)
+    params.require(:user).permit(:first_name, :last_name, :avatar, :birth_date, :email, :introduction)
   end
 end

--- a/app/javascript/components/pages/Top.vue
+++ b/app/javascript/components/pages/Top.vue
@@ -30,6 +30,17 @@
             >
               今すぐはじめる
             </v-btn>
+            <v-btn
+              v-if="!!currentUser"
+              dark
+              color="black"
+              class="mt-4 font-weight-bold"
+              x-large
+              :ripple="false"
+              :to="{ name: 'myReview' }"
+            >
+              マイページ
+            </v-btn>
           </v-col>
           <v-col
             align="center"

--- a/app/javascript/components/parts/SettingPlayer.vue
+++ b/app/javascript/components/parts/SettingPlayer.vue
@@ -11,12 +11,14 @@
             <!-- チーム選択 -->
             <v-col
               cols="12"
-              class="pt-2"
+              class="pt-2 mb-1"
             >
               <span
                 class="font-weight-bold grey--text text--darken-1"
                 :style="$vuetify.breakpoint.mobile ? 'font-size: 10px;' : 'font-size: 12px;'"
               >
+                生年月日を登録していないと選手登録はできません
+                <br>
                 選手登録をすることで評価を受けられるようになります(高校生のみ登録可能)
                 <br>
                 所属チームが見つからない場合はチームを登録してください

--- a/app/javascript/components/parts/SettingPlayer.vue
+++ b/app/javascript/components/parts/SettingPlayer.vue
@@ -179,6 +179,7 @@ import PlayerFormPosition from "./PlayerFormPosition"
 import PlayerFormNumber from "./PlayerFormNumber"
 import PlayerFormCareer from "./PlayerFormCareer"
 import TheTeamRegisterDialog from "./TheTeamRegisterDialog"
+import { mapGetters } from 'vuex'
 
 export default {
   components : {
@@ -222,6 +223,25 @@ export default {
       },
     }
   },
+  computed: {
+    ...mapGetters({ currentUser: "user/currentUser" }),
+    today() {
+      if (+this.$dayjs().format('MMDD') < +'0402') {
+        return this.$dayjs().subtract(1, 'year').format("YYYYMMDD")
+      } else {
+        return this.$dayjs().format("YYYYMMDD")
+      }
+    },
+    first() {
+      return this.$dayjs(this.today).subtract(15, 'year').format("YYYY0401")
+    },
+    third() {
+      return this.$dayjs(this.today).subtract(18, 'year').format("YYYY0402")
+    },
+    birth() {
+      return this.$dayjs(this.currentUser.birthDate).format("YYYYMMDD")
+    }
+  },
   created() {
     this.setData()
     this.serProfile()
@@ -252,6 +272,18 @@ export default {
       this.prefectures = response.data.prefectures
     },
     async sendPlayerData() {
+      if (!this.user.birthDate) {
+        return this.$store.dispatch("flash/setFlash", {
+          type: "error",
+          message: "生年月日の登録が必要です"
+        })
+      }
+      if (+this.birth < +this.third || +this.birth > +this.first) {
+        return this.$store.dispatch("flash/setFlash", {
+          type: "error",
+          message: "高校生のみ登録可能です"
+        })
+      }
       try {
         if (!this.user.profile) {
           const response = await this.$axios.post("/api/v1/users/current/profile", {

--- a/app/javascript/components/parts/SettingProfile.vue
+++ b/app/javascript/components/parts/SettingProfile.vue
@@ -35,6 +35,9 @@
               :style="$vuetify.breakpoint.mobile ? 'font-size: 10px;' : 'font-size: 12px;'"
             >
               メールアドレス変更時には再度アカウント認証が必要になります
+              <br>
+              選手登録には生年月日の登録が必要です(公開はされません)
+              <br>
             </span>
             <ValidationProvider
               v-slot="{ errors }"
@@ -71,6 +74,63 @@
                 @input="$emit('update:firstName', $event)"
               />
             </ValidationProvider>
+            <v-dialog
+              ref="dialog"
+              v-model="dateDialog"
+              :fullscreen="$vuetify.breakpoint.mobile"
+              :transition="$vuetify.breakpoint.mobile ? 'dialog-bottom-transition' : 'dialog-transition'"
+              width="330px"
+            >
+              <template #activator="{ on, attrs }">
+                <ValidationProvider
+                  v-slot="{ errors }"
+                  vid="birth_date"
+                  :rules="{ formFormat: /\d{4}-\d{2}-\d{2}/ }"
+                  name="生年月日"
+                >
+                  <v-text-field
+                    :value="birthDate"
+                    label="生年月日"
+                    outlined
+                    dense
+                    readonly
+                    v-bind="attrs"
+                    background-color="#F2F4F8"
+                    :error-messages="errors"
+                    v-on="on"
+                  />
+                </ValidationProvider>
+              </template>
+              <v-date-picker
+                :value="birthDate"
+                color="primary"
+                :active-picker.sync="activePicker"
+                :max="$dayjs().format('YYYY-MM-DD')"
+                min="1900-01-01"
+                full-width
+                :day-format="date => new Date(date).getDate()"
+                locale="jp-ja"
+                @input="$emit('update:birthDate', $event)"
+              >
+                <v-spacer />
+                <v-btn
+                  text
+                  color="primary"
+                  :ripple="false"
+                  @click="dateDialog = false"
+                >
+                  キャンセル
+                </v-btn>
+                <v-btn
+                  text
+                  color="primary"
+                  :ripple="false"
+                  @click="dateDialog = false"
+                >
+                  指定
+                </v-btn>
+              </v-date-picker>
+            </v-dialog>
             <ValidationProvider
               v-slot="{ errors }"
               name="メールアドレス"
@@ -161,6 +221,25 @@ export default {
       type: String,
       default: "",
       required: false
+    },
+    birthDate: {
+      type: String,
+      default: "",
+      required: false
+    }
+  },
+  data() {
+    return {
+      activePicker: "",
+      dateDialog: false
+    }
+  },
+  watch: {
+    menu (val) {
+      val && setTimeout(() => (this.activePicker = "YEAR"))
+    },
+    dateDialog (val) {
+      val && setTimeout(() => (this.activePicker = "YEAR"))
     }
   },
   methods: {

--- a/app/javascript/components/parts/SignupDialogForm.vue
+++ b/app/javascript/components/parts/SignupDialogForm.vue
@@ -69,125 +69,6 @@
                 cols="12"
                 class="pt-0"
               >
-                <v-dialog
-                  v-if="$vuetify.breakpoint.mobile"
-                  ref="dialog"
-                  v-model="dateDialog"
-                  fullscreen
-                  width="290px"
-                >
-                  <template #activator="{ on, attrs }">
-                    <ValidationProvider
-                      v-slot="{ errors }"
-                      vid="birth_date"
-                      :rules="{ required: true, formFormat: /\d{4}-\d{2}-\d{2}/ }"
-                      name="生年月日"
-                    >
-                      <v-text-field
-                        v-model="user.birth_date"
-                        label="生年月日"
-                        outlined
-                        dense
-                        readonly
-                        v-bind="attrs"
-                        background-color="#F2F4F8"
-                        required
-                        :error-messages="errors"
-                        v-on="on"
-                      />
-                    </ValidationProvider>
-                  </template>
-                  <v-date-picker
-                    v-model="user.birth_date"
-                    color="primary"
-                    :active-picker.sync="activePicker"
-                    :max="$dayjs().format('YYYY-MM-DD')"
-                    min="1900-01-01"
-                    full-width
-                    :day-format="date => new Date(date).getDate()"
-                    locale="jp-ja"
-                  >
-                    <v-spacer />
-                    <v-btn
-                      text
-                      color="primary"
-                      :ripple="false"
-                      @click="dialogCancel"
-                    >
-                      キャンセル
-                    </v-btn>
-                    <v-btn
-                      text
-                      color="primary"
-                      :ripple="false"
-                      @click="dateSave"
-                    >
-                      指定
-                    </v-btn>
-                  </v-date-picker>
-                </v-dialog>
-                <v-menu
-                  v-if="!$vuetify.breakpoint.mobile"
-                  ref="menu"
-                  v-model="menu"
-                  :close-on-content-click="false"
-                  transition="scale-transition"
-                  min-width="auto"
-                >
-                  <template #activator="{ on, attrs }">
-                    <ValidationProvider
-                      v-slot="{ errors }"
-                      vid="birth_date"
-                      :rules="{ required: true, formFormat: /\d{4}-\d{2}-\d{2}/ }"
-                      name="生年月日"
-                    >
-                      <v-text-field
-                        v-model="user.birth_date"
-                        label="生年月日"
-                        outlined
-                        dense
-                        readonly
-                        v-bind="attrs"
-                        background-color="#F2F4F8"
-                        required
-                        :error-messages="errors"
-                        v-on="on"
-                      />
-                    </ValidationProvider>
-                  </template>
-                  <v-date-picker
-                    v-model="user.birth_date"
-                    color="primary"
-                    :active-picker.sync="activePicker"
-                    :max="$dayjs().format('YYYY-MM-DD')"
-                    min="1900-01-01"
-                    :day-format="date => new Date(date).getDate()"
-                    locale="jp-ja"
-                  >
-                    <v-spacer />
-                    <v-btn
-                      text
-                      color="primary"
-                      :ripple="false"
-                      @click="menuCancel"
-                    >
-                      キャンセル
-                    </v-btn>
-                    <v-btn
-                      text
-                      color="primary"
-                      :ripple="false"
-                      @click="$refs.menu.save(user.birth_date)"
-                    >
-                      指定
-                    </v-btn>
-                  </v-date-picker>
-                </v-menu>
-              </v-col>
-              <v-col
-                cols="12"
-                class="pt-0"
-              >
                 <ValidationProvider
                   v-slot="{ errors }"
                   vid="email"
@@ -263,39 +144,16 @@ export default {
   data() {
     return {
       show: false,
-      menu: false,
-      dateDialog: false,
       activePicker: "",
       user: {
         first_name: "",
         last_name: "",
-        birth_date: "",
         email: "",
         password: ""
       }
     }
   },
-  watch: {
-    menu (val) {
-      val && setTimeout(() => (this.activePicker = "YEAR"))
-    },
-    dateDialog (val) {
-      val && setTimeout(() => (this.activePicker = "YEAR"))
-    }
-  },
   methods: {
-    menuCancel() {
-      this.menu = false
-      this.user.birth_date = ""
-    },
-    dialogCancel() {
-      this.dateDialog = false
-      this.user.birth_date = ""
-    },
-    dateSave() {
-      this.$refs.dialog.save(this.user.birth_date)
-      this.dateDialog = false
-    },
     async sendUserData() {
       try {
         await this.$axios.post("/api/v1/users", {

--- a/app/javascript/mixins/global-valiables.js
+++ b/app/javascript/mixins/global-valiables.js
@@ -315,7 +315,7 @@ export default {
     toTop() {
       window.scrollTo({
         top: 0,
-        behavior: 'auto'
+        behavior: "auto"
       })
     },
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
 
   validates :first_name, presence: true, length: { maximum: 30 }
   validates :last_name, presence: true, length: { maximum: 30 }
-  validates :birth_date, format: { with: /\d{4}-\d{2}-\d{2}/ }
+  validates :birth_date, format: { with: /\d{4}-\d{2}-\d{2}/ }, allow_blank: true
   validates :avatar, presence: true
   validates :role, presence: true
   validates :introduction, length: { maximum: 400 }


### PR DESCRIPTION
## やったこと
ログイン後にマイページボタンを追加
高校生のみ選手登録できるようにロジックを作成
新規登録時点では生年月日を登録させない
プロフィール編集で生年月日を登録させる

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
高校生しか選手登録はできない

## 動作確認
高校生のみ選手登録できることを確認
プロフィール編集で生年月日が登録できることを確認

## その他
特になし
