### PR TITLE
追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :test do
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'webdrivers'
+  gem 'database_cleaner'
 end
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1237,6 +1237,12 @@ GEM
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
     crass (1.0.6)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
     deep_merge (1.2.1)
@@ -1545,6 +1551,7 @@ DEPENDENCIES
   capybara
   carrierwave
   config
+  database_cleaner
   enum_help
   factory_bot_rails
   faker

--- a/spec/initial_data/01_league.rb
+++ b/spec/initial_data/01_league.rb
@@ -1,0 +1,3 @@
+League.seed(
+  name: '青森'
+)

--- a/spec/initial_data/02_category.rb
+++ b/spec/initial_data/02_category.rb
@@ -1,0 +1,4 @@
+Category.seed(
+  name: '3部',
+  league_id: 1
+)

--- a/spec/initial_data/03_group.rb
+++ b/spec/initial_data/03_group.rb
@@ -1,0 +1,4 @@
+Group.seed(
+  name: 'EAST',
+  category_id: 1
+)

--- a/spec/initial_data/04_prefecture.rb
+++ b/spec/initial_data/04_prefecture.rb
@@ -1,0 +1,3 @@
+Prefecture.seed(
+  name: '青森県'
+)

--- a/spec/initial_data/05_team.rb
+++ b/spec/initial_data/05_team.rb
@@ -1,0 +1,4 @@
+Team.seed(
+  name: '青森山田高校',
+  prefecture_id: 1
+)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,4 +94,10 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean_with(:truncation)
+    fixture_path = "#{Rails.root}/spec/initial_data"
+    SeedFu.seed(fixture_path)
+  end
 end


### PR DESCRIPTION
## やったこと
テスト実行時にデータベースの初期化とテストデータの作成
データベースの初期化はdatabase_clanerを使用
テストデータはspec/initial_data以下に作成

## やらないこと
特になし

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
特になし

## 動作確認
テスト実行時にデータベースの初期化とテストデータの作成が行われることを確認

## その他
特になし
